### PR TITLE
Implements Jupyter notebook for Python alternative to `project_analysis.R`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+#Jupyter Notebook
+.ipynb_checkpoints
+
+#scanpy
+cache
+
+#other
+.DS_store

--- a/README.md
+++ b/README.md
@@ -10,7 +10,23 @@ This project was inspired by the work of [Ido Nofech-Mozes et al.](https://www.n
 
 # **Data:**
 
-This project specifically builds upon the work above by attempting to replicate their results using a [separate dataset](https://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc=GSE176078) of 26 combined HER2+, ER+, and TNBC-specific patient samples.
+This project specifically builds upon the work above by attempting to replicate their results using a [separate dataset](https://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc=GSE176078) of 26 combined HER2+, ER+, and TNBC-specific patient samples. The supplementary file `GSE176078_Wu_etal_2021_BRCA_scRNASeq.tar.gz` can be found at the bottom of the GEO page and is the basis for this analysis.
 
-The raw script for conducting this project's analysis is described in the `analysis/project_analysis.R` file. A subsequent markdown file and formal report that contains this raw code in combination with further annotations, links to literature supporting findings, figures/plots, and continued discussion and future directions can be seen in the files `report/project_analysis_markdown.Rmd` and `report/project_analysis_report.html` respectively. Due to the file size viewing limitations on GitHub, the formal report file `report/project_analysis_report.html` may need to be downloaded in order to be viewed. 
+The dataset should be downloaded and unzipped, and its contents placed into its own directory labeled `data` at the same level as `analysis` and `report`. Within this new directory, the following files should be present:
+1) barcodes.tsv
+2) genes.tsc
+3) matrix.mtx
+4) metadata.csv
+
+# **Workflow:**
+
+An R script for conducting this project's analysis is described in the `analysis/project_analysis.R` file. A subsequent markdown file and formal report that contains this raw code in combination with further annotations, links to literature supporting findings, figures/plots, and continued discussion and future directions can be seen in the files `report/project_analysis_markdown.Rmd` and `report/project_analysis_report.html` respectively. 
+
+Due to the file size viewing limitations on GitHub, the formal report file `report/project_analysis_report.html` may need to be downloaded in order to be viewed. 
+
+A Python alternative to the analysis performed in `analysis/project_analysis.R` is currently being developed, and is viewable in the Jupyter notebook `analysis/project_analysis.ipynb`. In the near future, a .py script will also be implemented to run this analysis and display plots of interest for a specified BC subtype.
+
+
+
+
 

--- a/analysis/project_analysis.ipynb
+++ b/analysis/project_analysis.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 76,
    "id": "97cd7650-7a4a-402d-b450-4d2d84e6c1a1",
    "metadata": {
     "tags": []
@@ -10,12 +10,61 @@
    "outputs": [],
    "source": [
     "import pandas as pd\n",
-    "import scanpy as sc"
+    "import scanpy as sc\n",
+    "import matplotlib.pyplot as plt"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "58ead1c6-cc18-458d-98ab-2a5928152f74",
+   "metadata": {},
+   "source": [
+    "__Set Parameters for Loading Data + Analysis:__"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 55,
+   "id": "0d1e2cd1-c017-4c5d-921b-0e5ab35b278c",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "#set file path of data folder\n",
+    "data_path = '../data/'\n",
+    "\n",
+    "#set BC subtype to analyze\n",
+    "subtype = \"HER2+\" #options are \"HER2+\", \"ER+\", or \"TNBC\"\n",
+    "\n",
+    "#set QC thresholds\n",
+    "nfeature_min = 200\n",
+    "nfeature_max = 2500\n",
+    "ncount_min = 500\n",
+    "percent_mt_max = 10"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bac82d71-47f2-4f52-b0c7-7c55cfb48ec8",
+   "metadata": {},
+   "source": [
+    "__Edit Data Into Correct Formatting__:\n",
+    "    \n",
+    "Data files need to be edited into a readable format before analysis can begin"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "02b95b5f-0ed4-41bf-829a-f23816c2b2e7",
+   "metadata": {},
+   "source": [
+    "1) genes.tsv"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
    "id": "a7adfddf-a288-4dae-ad79-6c22d65838c6",
    "metadata": {
     "tags": []
@@ -32,39 +81,16 @@
     "df_genes = df_genes[['GeneID', 'GeneName']]\n",
     "\n",
     "#save to genes.tsv\n",
-    "df_genes.to_csv('../data/genes.tsv', sep='\\t', index=False, header=False)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 6,
-   "id": "b64a54ad-d264-47bd-ab84-ea3f5ddb87ee",
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "        0              1\n",
-      "0  Gene_0   RP11-34P13.7\n",
-      "1  Gene_1     FO538757.3\n",
-      "2  Gene_2     FO538757.2\n",
-      "3  Gene_3     AP006222.2\n",
-      "4  Gene_4  RP4-669L17.10\n"
-     ]
-    }
-   ],
-   "source": [
+    "df_genes.to_csv('../data/genes.tsv', sep='\\t', index=False, header=False)\n",
+    "\n",
     "#load tsv file into DataFrame\n",
     "df = pd.read_csv('../data/genes.tsv', sep='\\t', header = None)\n",
-    "print(df.head())"
+    "#print(df.head())"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 7,
    "id": "434cbdd3-9d17-4da2-abcb-1fd942049929",
    "metadata": {
     "tags": []
@@ -80,13 +106,312 @@
     }
    ],
    "source": [
-    "#set file path\n",
-    "data_path = '../data/'\n",
-    "\n",
     "#read in data\n",
     "adata = sc.read_10x_mtx(data_path, var_names='gene_symbols', cache=True)\n",
-    "print(adata)"
+    "#print(adata)"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e9dd26e9-0467-4270-be76-01f5cf355c97",
+   "metadata": {},
+   "source": [
+    "2) metadata.csv"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "id": "753d7d16-faff-4e73-a029-00062a51f0f5",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "#load in metadata\n",
+    "metadata = pd.read_csv(data_path + 'metadata.csv')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "id": "b4f216bc-f0fb-4c87-8e02-f7b2b8d3089e",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "#create cell_id header for unique cell identifiers\n",
+    "new_headers = ['cell_id'] + list(metadata.columns[1:])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "id": "fdcffaa1-260a-4f1a-874b-59135f1a1434",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "#assign cell_id header to cells\n",
+    "metadata.columns = new_headers\n",
+    "#print(metadata.head())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 34,
+   "id": "f46d66ac-6451-44c5-bc53-9f759a8f775e",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "#save metadata w/header\n",
+    "metadata.to_csv(data_path + 'metadata.csv', index=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 40,
+   "id": "9c8649e5-c5fe-4ee0-a447-65016715d5b9",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "#merge data + metadata by cell_id\n",
+    "adata.obs = adata.obs.join(metadata.set_index('cell_id'))\n",
+    "#print(adata.obs.head())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6fc93e40-84c8-4aa9-9f2b-5e3a38c2e16f",
+   "metadata": {},
+   "source": [
+    "__Set AnnData Object for Downstream Analysis:__"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 44,
+   "id": "2358e3bb-aa5e-45fe-b2c6-1e777c08f497",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "#set copy of raw data\n",
+    "adata.raw = adata"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dba4291b-0abf-4545-966f-775911060559",
+   "metadata": {},
+   "source": [
+    "__QC and Subsetting:__"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 59,
+   "id": "63536bfd-a091-449c-b8b3-0638e30236c7",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                         orig.ident  nCount_RNA  nFeature_RNA  percent.mito  \\\n",
+      "CID3586_AAGACCTCAGCATGAG    CID3586        4581          1689      1.506221   \n",
+      "CID3586_AAGGTTCGTAGTACCT    CID3586        1726           779      5.793743   \n",
+      "CID3586_ACCAGTAGTTGTGGCC    CID3586        1229           514      1.383238   \n",
+      "CID3586_ACCCACTAGATGTCGG    CID3586        1352           609      1.923077   \n",
+      "CID3586_ACTGATGGTCAACTGT    CID3586        1711           807     13.325541   \n",
+      "\n",
+      "                         subtype    celltype_subset     celltype_minor  \\\n",
+      "CID3586_AAGACCTCAGCATGAG   HER2+  Endothelial ACKR1  Endothelial ACKR1   \n",
+      "CID3586_AAGGTTCGTAGTACCT   HER2+  Endothelial ACKR1  Endothelial ACKR1   \n",
+      "CID3586_ACCAGTAGTTGTGGCC   HER2+  Endothelial ACKR1  Endothelial ACKR1   \n",
+      "CID3586_ACCCACTAGATGTCGG   HER2+  Endothelial ACKR1  Endothelial ACKR1   \n",
+      "CID3586_ACTGATGGTCAACTGT   HER2+  Endothelial ACKR1  Endothelial ACKR1   \n",
+      "\n",
+      "                         celltype_major  percent_mt  \n",
+      "CID3586_AAGACCTCAGCATGAG    Endothelial    1.506221  \n",
+      "CID3586_AAGGTTCGTAGTACCT    Endothelial    5.793743  \n",
+      "CID3586_ACCAGTAGTTGTGGCC    Endothelial    1.383238  \n",
+      "CID3586_ACCCACTAGATGTCGG    Endothelial    1.923077  \n",
+      "CID3586_ACTGATGGTCAACTGT    Endothelial   13.325541  \n"
+     ]
+    }
+   ],
+   "source": [
+    "#calculate % mitochondrial DNA per sample\n",
+    "mito_genes = adata.var_names.str.startswith('MT-')\n",
+    "adata.obs['percent_mt'] = adata[:, mito_genes].X.sum(axis=1) / adata.X.sum(axis=1) * 100\n",
+    "#print(adata.obs.head())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 61,
+   "id": "3b69f315-3aa8-4c5d-acfd-2c50b72a0d2e",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "#filter samples based on QC metrics\n",
+    "adata = adata[(\n",
+    "    (adata.obs['nFeature_RNA'] > nfeature_min) &\n",
+    "    (adata.obs['nFeature_RNA'] < nfeature_max) &\n",
+    "    (adata.obs['nCount_RNA'] > ncount_min) &\n",
+    "    (adata.obs['percent_mt'] < percent_mt_max)\n",
+    ")]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 63,
+   "id": "77b9f691-5965-4271-adcd-9074c11e5086",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "#set samples to analyze to specified subtype\n",
+    "adata = adata[adata.obs['subtype'] == subtype]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "91dcc969-bfa8-4b4b-af12-18c6399b4342",
+   "metadata": {},
+   "source": [
+    "__Normalization:__"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 72,
+   "id": "0c4a556b-644d-4505-8546-5b5b4c9b0b8d",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/joshuagalla/anaconda3/lib/python3.11/site-packages/scanpy/preprocessing/_normalization.py:207: UserWarning: Received a view of an AnnData. Making a copy.\n",
+      "  view_to_actual(adata)\n"
+     ]
+    }
+   ],
+   "source": [
+    "sc.pp.normalize_total(adata, target_sum=1e6)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 96,
+   "id": "b9297769-b20d-4f25-b498-4d92c08128c3",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAnIAAAGKCAYAAACIB6x8AAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjguNCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8fJSN1AAAACXBIWXMAAA9hAAAPYQGoP6dpAABYC0lEQVR4nO3deXhU9aH/8fcsyWSf7BtEQHZkEcKuFdwQFa3d9NZKrfWqt1Ytiku9T2u1tVD1p95Wba/eWhdatZsLuGMtoOwg+5IECJBAQhKSTEK2mTlzfn+EDERAtgknM/N5Pc88mjnfTD6TR5NPvuec79dmmqaJiIiIiIQdu9UBREREROTUqMiJiIiIhCkVOREREZEwpSInIiIiEqZU5ERERETClIqciIiISJhSkRMREREJUypyIiIiImHKaXWAcBEIBNi7dy/JycnYbDar44iIiEgEM02TxsZG8vPzsduPPe+mIneC9u7dS0FBgdUxREREJIqUlZXRs2fPYx5XkTtBycnJQPs3NCUlxeI0IiIiEskaGhooKCgI9o9jUZE7QR2nU1NSUlTkRERE5Iw43uVcutlBREREJEypyImIiIiEKRU5ERERkTClIiciIiISplTkRERERMKUipyIiIhImFKRExEREQlTKnIiIiIiYcrSIjd79mzGjBlDcnIy2dnZXHPNNRQVFXUa84Mf/ACbzdbpMX78+E5j2trauPPOO8nMzCQxMZGrr76a8vLyTmPq6uqYPn06brcbt9vN9OnTqa+v7+q3KCIiItJlLC1yCxcu5Mc//jHLli1j/vz5+P1+pkyZQlNTU6dxU6dOpaKiIvh4//33Ox2fMWMGb731Fm+88Qaff/45Bw4cYNq0aRiGERxz/fXXs3btWj788EM+/PBD1q5dy/Tp08/I+xQRERHpCjbTNE2rQ3Sorq4mOzubhQsXcsEFFwDtM3L19fW8/fbbR/0cj8dDVlYWc+bM4brrrgMObXD//vvvc9lll7FlyxaGDBnCsmXLGDduHADLli1jwoQJbN26lYEDBx43W0NDA263G4/Hoy26REREpEudaO/oVtfIeTweANLT0zs9v2DBArKzsxkwYAC33HILVVVVwWOrV6/G5/MxZcqU4HP5+fkMHTqUJUuWALB06VLcbnewxAGMHz8et9sdHCMiIiISbpxWB+hgmib33HMP559/PkOHDg0+f/nll/Od73yHXr16UVpays9//nMuuugiVq9ejcvlorKyktjYWNLS0jq9Xk5ODpWVlQBUVlaSnZ19xNfMzs4OjvmytrY22tragh83NDSE4m2KSIQwDIN33nmHPXv2hOT17HY7U6ZMoX///iF5PRGJDt2myN1xxx2sX7+ezz//vNPzHadLAYYOHcro0aPp1asX7733Ht/85jeP+XqmaWKz2YIfH/7vxxpzuNmzZ/PII4+c7NsQkSjxyiuv8Oqrr4b0NT/44ANeeOEF8vPzQ/q6IhK5ukWRu/POO5k7dy6LFi2iZ8+eXzk2Ly+PXr16UVJSAkBubi5er5e6urpOs3JVVVVMnDgxOGbfvn1HvFZ1dTU5OTlH/ToPPvgg99xzT/DjhoYGCgoKTvq9iUjkWbx4Ma+++iqBuBRazr4QbKd/lYqjsQJ2L+PnP/85zz33HHFxcSFIKiKRztJr5EzT5I477uDNN9/k008/pU+fPsf9nP3791NWVkZeXh4AhYWFxMTEMH/+/OCYiooKNm7cGCxyEyZMwOPxsGLFiuCY5cuX4/F4gmO+zOVykZKS0ukhIlJWVsavf/1rsDtp6XsxgcQMAglpp/3w5QzBmz2Y7du38+STT9KN7kMTkW7M0iL34x//mD//+c+89tprJCcnU1lZSWVlJS0tLQAcOHCAe++9l6VLl7Jz504WLFjAVVddRWZmJt/4xjcAcLvd3HzzzcycOZN//etfrFmzhhtuuIFhw4ZxySWXADB48GCmTp3KLbfcwrJly1i2bBm33HIL06ZNO6E7VkVEoP3a2V/84hc0NzfT0vt8Aglpx/+kk3n9grEYSdnMnz+fd999N6SvLSKRydIi94c//AGPx8PkyZPJy8sLPv76178C4HA42LBhA1//+tcZMGAAN954IwMGDGDp0qUkJycHX+fpp5/mmmuu4dprr+W8884jISGBefPm4XA4gmP+8pe/MGzYMKZMmcKUKVMYPnw4c+bMOePvWUTC13PPPceOHTvwZg/Gn3F26L+A3UFL3wsxnXH87pln2LFjR+i/hohElG61jlx3pnXkRKLbggULePjhhzES0mkePA3sXXeJsaO+jISS+RScdRYvPP888fHxXfa1RKR7Cst15EREuqOamhoef+IJcDhp6Xthl5Y4ACO1AG/OUMp27+YPf/hDl34tEQlvKnIiIsfx29/+luamJloLxmPGuc/I12zrWYgRn8bcuXNZv379GfmaIhJ+VORERL7CokWL+Oyzz/An5+HLPIOL9dodtPY+H7DxxBNPdFqgXESkg4qciMgxNDc38z//8z8HS9V5cIwFxLtKICkLb84QysrKeP3118/o1xaR8KAiJyJyDG+++Sa1tbW05Y3AjLPmJqe2HqMwYxN4469/pb6+3pIMItJ9qciJiBxFY2Mjr7/+BqYzDm/OOdYFccTQljeC1pYWzcqJyBFU5EREjuLvf/87TU0HaMsbDo4YS7P4Mgdgxibx5ltvsX//fkuziEj3oiInIvIlXq+Xt995BzMmHl/2IKvjgN1BW/4IfF6vdnwQkU5U5EREvuTzzz+nwePBm9G/y9eMO1G+9L7giOXdd9/DMAyr44hIN6EiJyLyJR2zXr6sARYnOYzDiTejL9XVVaxcudLqNCLSTajIiYgcprq6mi+++AJ/cp5ld6oeS0ex/Pjjjy1OIiLdhYqciMhhli5dCoA/vbe1QY4iEJ9OwJXC8uXL8fl8VscRkW5ARU5E5DCLFy8GwJ96lsVJjsJmw59aQFNTk7btEhFARU5EJKitrY0vvvgCIyEDMzbR6jhH1VEwO2YORSS6qciJiBy0efNmfD4fRkq+1VGOyUjKBruDdevWWR1FRLoBFTkRkYM6Tlf6k3MsTvIV7A78idls27adAwcOWJ1GRCymIiciclBHkTOSunGRA4zkHEwzwKZNm6yOIiIWU5ETEQECgQBbtmzBiEsFp8vqOF/JSMoGYMuWLRYnERGrqciJiAB79uyhubmZQGKm1VGOyziYcevWrRYnERGrqciJiHCoFBlhUORwxhFwJbN161ZM07Q6jYhYSEVORAQoKSkBwqTIAUZCBvX19ezfv9/qKCJiIRU5ERFg27ZtAATi0yxOcmICCenAodwiEp1U5EQk6pmmybZt2wjEpYAjxuo4J8RIyABg+/btFicRESupyIlI1Nu/fz8NDQ0Y8elWRzlhmpETEVCRExEJzmp1lKNwYMYkYDpi2bFjh9VRRMRCKnIiEvVKS0uB8Lk+DgCbDSM+jbKyMrxer9VpRMQiKnIiEvU6ipwRTkWO9uIZCATYvXu31VFExCIqciIS9UpLS8HuxHQlWx3lpAQS2ovnzp07rQ0iIpZRkRORqBYIBNi5axdGnBtsNqvjnJRAXCqgIicSzVTkRCSqVVZW4m1rC6/r4w7qyNxxalhEoo+KnIhEtY7ZrEB8qqU5ToUZE4cZE8/OXbusjiIiFlGRE5GotutgCTLCsMgBGHFu9u7dS1tbm9VRRMQCKnIiEtWCM3IHrzcLN4H4VMxAgLKyMqujiIgFVOREJKrt2rUL7A5MV5LVUU5JRwHdpdOrIlFJRU5EopZpmofdsRqePw47ru3TWnIi0Sk8f3KJiIRAdXU1rS0tYXtaFQ4VOS1BIhKdVOREJGqF8x2rHUxnPKbTpSInEqVU5EQkakVCkcNmw4hzU15ejt/vtzqNiJxhKnIiErU6ipwRF36LAR8uEJ+GYRiUl5dbHUVEzjAVORGJWqWlpWCzY8aF1x6rX9Yxo6gdHkSij4qciESlQCBAaWlp+0LAYXrHaodAfDoAO3bssDiJiJxp4f3TS0TkFFVUVNDa2hosQeGsY89VFTmR6KMiJyJRqaP0GPHhfX0cdOy5msD27dutjiIiZ5iKnIhEpZKSEgACCeE/IwdgJKRTWVlJY2Oj1VFE5AxSkRORqNRR5IzEDIuThIZxsJBu27bN4iQiciapyIlIVCopKSEQmwjOOKujhEQgob2QqsiJRBcVORGJOrW1tdTU1GAkRMZsHBB8L0VFRRYnEZEzSUVORKJOcXExAIHETIuThI7pSsZ0uoLvTUSig4qciESdjrITSTNy2GwYCRmUlZXR3NxsdRoROUNU5EQk6nScfoykGTloL6amaeo6OZEooiInIlGnqLiYQGwiZky81VFCqqOY6jo5keihIiciUaW2tpaa6urIOq16UMd70nVyItFDRU5EokpwIeAIO60KB294cMSqyIlEERU5EYkqwYWAI2RHh05sNoyEdHaXldHa2mp1GhE5A1TkRCSqHNqaK/JOrUL7+zIDAe27KhIlVOREJKps27YN09m+yXwkMrTDg0hUUZETkajR3NzM3r1720+r2mxWx+kSAe25KhJVVOREJGrs2LED0zQj9rQqQCAuFWx2nVoViRIqciISNTrKTUTe6NDBbseIT2P79u0YhmF1GhHpYpYWudmzZzNmzBiSk5PJzs7mmmuuOWIhS9M0efjhh8nPzyc+Pp7JkyezadOmTmPa2tq48847yczMJDExkauvvpry8vJOY+rq6pg+fTputxu328306dOpr6/v6rcoIt1IcI/VSC5ytBfVtra2I34OikjksbTILVy4kB//+McsW7aM+fPn4/f7mTJlCk1NTcExjz/+OE899RTPPvssK1euJDc3l0svvZTGxsbgmBkzZvDWW2/xxhtv8Pnnn3PgwAGmTZvW6a/R66+/nrVr1/Lhhx/y4YcfsnbtWqZPn35G36+IWKu4uBjsTgJxbqujdKmOU8cdd+iKSOSymaZpWh2iQ3V1NdnZ2SxcuJALLrgA0zTJz89nxowZPPDAA0D77FtOTg6PPfYYt912Gx6Ph6ysLObMmcN1110HwN69eykoKOD999/nsssuY8uWLQwZMoRly5Yxbtw4AJYtW8aECRPYunUrAwcOPG62hoYG3G43Ho+HlJSUrvsmiEiX8Pl8TL38cryuNJqHXGV1nC5lP1BF4pZ3ufbaa7n99tutjiMip+BEe0e3ukbO4/EAkJ7eftqjtLSUyspKpkyZEhzjcrmYNGkSS5YsAWD16tX4fL5OY/Lz8xk6dGhwzNKlS3G73cESBzB+/HjcbndwzJe1tbXR0NDQ6SEi4Wvbtm0Yfj9GYpbVUbpcICEdbHY2b95sdRQR6WLdpsiZpsk999zD+eefz9ChQwGorKwEICcnp9PYnJyc4LHKykpiY2NJS0v7yjHZ2dlHfM3s7OzgmC+bPXt28Ho6t9tNQUHB6b1BEbFUx7W1RlLkFznsToz4dIqKivD5fFanEZEu1G2K3B133MH69et5/fXXjzhm+9J6T6ZpHvHcl315zNHGf9XrPPjgg3g8nuCjrKzsRN6GiHRTh4rckX/URSIjKRufz6f15EQiXLcocnfeeSdz587l3//+Nz179gw+n5ubC3DErFlVVVVwli43Nxev10tdXd1Xjtm3b98RX7e6uvqI2b4OLpeLlJSUTg8RCU+mabJ23TrMmATM2CSr45wRRnJ7YV23bp3FSUSkK1la5EzT5I477uDNN9/k008/pU+fPp2O9+nTh9zcXObPnx98zuv1snDhQiZOnAhAYWEhMTExncZUVFSwcePG4JgJEybg8XhYsWJFcMzy5cvxeDzBMSISuXbu3EldbS3+lPyI3dHhy4zkPKD9OmIRiVxOK7/4j3/8Y1577TXeeecdkpOTgzNvbreb+Ph4bDYbM2bMYNasWfTv35/+/fsza9YsEhISuP7664Njb775ZmbOnElGRgbp6ence++9DBs2jEsuuQSAwYMHM3XqVG655Raef/55AG699VamTZt2Qnesikh46ygz/pQ8i5OcOWZMPEZ8OuvWrcfr9RIbG2t1JBHpApYWuT/84Q8ATJ48udPzL730Ej/4wQ8AuP/++2lpaeH222+nrq6OcePG8fHHH5OcnBwc//TTT+N0Orn22mtpaWnh4osv5uWXX8bhcATH/OUvf+Guu+4K3t169dVX8+yzz3btGxSRbqFjNt5Iybc4yZlluPPxVm5k/fr1jB492uo4ItIFutU6ct2Z1pETCU/Nzc1cffXVtMW6aT7n61bHOaMcDRUkFH3AN7/5Te666y6r44jISQjLdeREREJt1apV+P1+/KlnWR3ljDOSczCdLhYvXoz+ZheJTCpyIhLRFi9eDIA/NQrXgrTZ8af0ZN++fWzfvt3qNCLSBVTkRCRi+f1+Pl+8mEBsUnD/0WjjT+sFwGeffWZxEhHpCipyIhKx1qxZQ9OBA+1lJkqWHfkyv7sH2J0sWrTI6igi0gVU5EQkYnWUF39ab2uDWMkRgy+lB6WlpZSXl1udRkRCTEVORCJSIBBg8eIl7eupRcP+ql/Bn9Z+o8fnn39ucRIRCTUVORGJSEVFRdTW7sfnLgBbdP+o86cWgM0WvPFDRCJHdP90E5GIFbxbNS36lh05gjMOf1IOGzduor6+3uo0IhJCKnIiEpFWrFgBNjtGcnTt5nAsfncBphnQ3qsiEUZFTkQijsfjoaSkBH9SDjgs3Ymw2zDc7YVWRU4ksqjIiUjEWbNmDaZpRt3eql8lEJ+O6Yxj5cpV2uVBJIKoyIlIxNmwYQMA/pQ8i5N0IzYb/uRcqqurqKqqsjqNiISIipyIRJytW7eCzR61uzkci5HYvgzL1q1bLU4iIqGiIiciEcXv91NcUoIRnw52h9VxupVAkoqcSKRRkRORiLJ79258Xi9Gombjvsw4OENZXFxscRIRCRUVORGJKLt37wYgEJ9qbZDuyBFDIDaR3bvLrE4iIiGiIiciESVY5OLcFifpngJxqVRXV9HS0mJ1FBEJARU5EYkoe/bsAVTkjqXj+9LxfRKR8KYiJyIRpbKyErBhxiZaHaVbCrjavy9agkQkMqjIiUhEqaqqIhCbADb9eDuajoKrIicSGfSTTkQihmmaVFdXY8ZoNu5YArFJgIqcSKRQkRORiNHQ0IDf72+fkZOjMmPavzf79++3OImIhIKKnIhEjNraWgDMmHiLk3RfHd+bju+ViIQ3FTkRiRgqcifA7sB0ulTkRCKEipyIRIyO04Udpw/l6ALOeJ1aFYkQKnIiEjE6ZpkCmpH7SmZMPB6PB7/fb3UUETlNKnIiEjF0avXEmDHxmKZJfX291VFE5DSpyIlIxKipqQF0avV4zIN39XZ8v0QkfKnIiUjEqKqqAptdM3LHETi4zl51dbXFSUTkdKnIiUjEqKqqIhCTADab1VG6Ne3uIBI5VOREJCL4/X72799PQHusHlfH92jfvn0WJxGR06UiJyIRobKyEsMwMONSrI7S7QUOfo/27NljcRIROV0qciISETpKScClIndcThem00V5ebnVSUTkNKnIiUhEKCsrAw7NNslXC7hS2LNnj9aSEwlzKnIiEhG2b98OQCA+zeIk4cFISMPv9wcLsIiEJxU5EYkIJSUlYHdqRu4EBRIygIPfNxEJWypyIhL2vF4vpTt3YiSkg00/1k6EoSInEhH0E09Ewt6WLVsw/H6MxCyro4SNQEI62B2sX7/e6igichpU5EQk7K1ZswYAf0qexUnCiN2JPzGL4uISGhsbrU4jIqdIRU5Ewl57kbNhJOVaHSWsGMl5mGZAs3IiYUxFTkTCmsfjYcOGDe2nVZ2xVscJK353DwCWLl1qcRIROVUqciIS1pYsWUIgEMCX3svqKGEnkJiFGZPAos8+03pyImFKRU5EwtrChQsB8Kf1tjZIOLLZ8KX1puHgrKaIhB8VOREJW3V1daxctQojIRPTlWx1nLDkT+8NwPz5860NIiKnREVORMLWxx9/jOH348vqb3WUsGUk5RBwJfPpp5/S3NxsdRwROUkqciISlkzT5L333gO7A1/62VbHCV82G77MAbS2tvLpp59anUZETpKKnIiEpQ0bNrB79258ab3B6bI6TljzZfYHm4158+ZhmqbVcUTkJKjIiUhYevPNNwHwZg2yOEn4M2MT8KX2oqioiM2bN1sdR0ROgoqciISdqqoqFi1ahJGQQSAp2+o4EcGXPRiAt956y+IkInIyVOREJOzMmzePQCCAN2cI2GxWx4kIRnIuRnwa/16wgP3791sdR0ROkIqciIQVr9fbfi2XMw5/eh+r40QOmw1f9mAMv7/9JhIRCQsqciISVhYtWkR9fT3ezP5gd1odJ6L4MvqCI5Z35s7VTg8iYUJFTkTCSsc1XL5s3eQQco4YvJn92F9Tw5IlS6xOIyInQEVORMLG7t272bRpE353T+3k0EV8B+8Cfv/99y1OIiInQkVORMLGRx99BBxc90y6RCA+FSMxixUrVlBbW2t1HBE5DhU5EQkLgUCAjz7+GNMZiz+1wOo4Ec2X2Y9AIMAnn3xidRQROQ4VOREJC1u2bKGmurp9Jwfd5NClfOlng83OwoULrY4iIsehIiciYWHp0qUA+FN7WZwkCjhd+JNy2Lx5M/X19VanEZGvYGmRW7RoEVdddRX5+fnYbDbefvvtTsd/8IMfYLPZOj3Gjx/faUxbWxt33nknmZmZJCYmcvXVV1NeXt5pTF1dHdOnT8ftduN2u5k+fbp+OImEmaVLl4LdgZGcZ3WUqOBP7YlpmqxYscLqKCLyFSwtck1NTYwYMYJnn332mGOmTp1KRUVF8PHlO6lmzJjBW2+9xRtvvMHnn3/OgQMHmDZtGoZhBMdcf/31rF27lg8//JAPP/yQtWvXMn369C57XyISWrW1tWzfvh1/ch44dFr1TDDc7dchqsiJdG+W/kS8/PLLufzyy79yjMvlIjc396jHPB4PL774InPmzOGSSy4B4M9//jMFBQV88sknXHbZZWzZsoUPP/yQZcuWMW7cOAD+7//+jwkTJlBUVMTAgQND+6ZEJOQ6NnI3knIsThI9AnFuTGdc8HsvIt1Tt79GbsGCBWRnZzNgwABuueUWqqqqgsdWr16Nz+djypQpwefy8/MZOnRocDHLpUuX4na7gyUOYPz48bjd7q9c8LKtrY2GhoZODxGxxqEil21xkihis2EkZrF3715diiLSjXXrInf55Zfzl7/8hU8//ZQnn3ySlStXctFFF9HW1gZAZWUlsbGxpKWldfq8nJwcKisrg2Oys4/84Z+dnR0cczSzZ88OXlPndrspKNByByJW2bJlC2DDSMy0OkpU6SjO7d9/EemOunWRu+6667jyyisZOnQoV111FR988AHFxcXH3dDZNE1sNlvw48P//VhjvuzBBx/E4/EEH2VlZaf+RkTktOzYUUogLhkcMVZHiSpGQjoApaWlFicRkWPp1kXuy/Ly8ujVqxclJSUA5Obm4vV6qaur6zSuqqqKnJyc4Jh9+/Yd8VrV1dXBMUfjcrlISUnp9BCRM6++vh6Ppx4jLtXqKFEnEJ8KwM6dOy3NISLHFlZFbv/+/ZSVlZGX1778QGFhITExMcyfPz84pqKigo0bNzJx4kQAJkyYgMfj6XTn1fLly/F4PMExItJ9dZSIQHzaVw+UkDNjk8DuVJET6cZO+a7Vbdu2sX37di644ALi4+OPe6ryaA4cOMC2bduCH5eWlrJ27VrS09NJT0/n4Ycf5lvf+hZ5eXns3LmT//7v/yYzM5NvfOMbALjdbm6++WZmzpxJRkYG6enp3HvvvQwbNix4F+vgwYOZOnUqt9xyC88//zwAt956K9OmTdMdqyJhoOOyhkCc2+IkUchmw4hLYXdZ2Sn9jBeRrnfSM3L79+/nkksuYcCAAVxxxRVUVFQA8J//+Z/MnDnzpF5r1apVjBw5kpEjRwJwzz33MHLkSB566CEcDgcbNmzg61//OgMGDODGG29kwIABLF26lOTk5OBrPP3001xzzTVce+21nHfeeSQkJDBv3jwcDkdwzF/+8heGDRvGlClTmDJlCsOHD2fOnDkn+9ZFxAIdC3yryFkj4HLT2tJCbW2t1VFE5ChOekbu7rvvxul0snv3bgYPHhx8/rrrruPuu+/mySefPOHXmjx5MqZpHvP4Rx99dNzXiIuL45lnnuGZZ5455pj09HT+/Oc/n3AuEek+DhU5XadqhY7ve1lZGRkZGRanEZEvO+kZuY8//pjHHnuMnj17dnq+f//+7Nq1K2TBREQAdu/ejemMA6fL6ihR6fAiJyLdz0kXuaamJhISEo54vqamBpdLP2hFJHR8Ph979uzBOHj3pJx5HTeZ6A91ke7ppIvcBRdcwKuvvhr82GazEQgEeOKJJ7jwwgtDGk5Eolt5eTmBQEDXx1mo43uvIifSPZ30NXJPPPEEkydPZtWqVXi9Xu6//342bdpEbW0tixcv7oqMIhKlOhaiDWhGzjqOGAKxSWzfvsPqJCJyFCc9IzdkyBDWr1/P2LFjufTSS2lqauKb3/wma9asoW/fvl2RUUSi1NatWwEwErQ1l5WMxAxqa/dTU1NjdRQR+ZJTWkcuNzeXRx55JNRZREQ6KSoqAmwEEnS3pJUCCZlQt4vi4mIyM1WqRbqTky5yixYt+srjF1xwwSmHERHp4Pf7KSoubr/RwXHKa5dLCBiJ7eVt8+bN2hFHpJs56Z+OkydPPuK5w1f7NgzjtAKJiED7bFxrSwtGdm+ro0Q9IykbbHbWrl1rdRQR+ZKTvkaurq6u06OqqooPP/yQMWPG8PHHH3dFRhGJQh2lwUjOszaIgCMGf2ImW7Zsobm52eo0InKYk56Rc7uPXAbg0ksvxeVycffdd7N69eqQBBOR6Nbxs8SfkmtxEoH2Qm0cqGLdunVMmDDB6jgictBJz8gdS1ZW1sELk0VETk9jYyPr1q3DSMwCZ5zVcQTwu9t381myZInFSUTkcCc9I7d+/fpOH5umSUVFBb/5zW8YMWJEyIKJSPRavnw5hmHgTzvL6ihyUCApCzMmnsWLl3D33Xdjt4dsHkBETsNJF7lzzz0Xm812xGb348eP509/+lPIgolI9Pr8888B8Kf2sjiJBNns+NwF1NYUs3XrVoYMGWJ1IhHhFIpcx0rrHex2O1lZWcTF6fSHiJy+5uZmlixZSiDOra25uhl/Wi9ia4r59NNPVeREuomTLnK9eukvZBHpOosXL8brbcPX4xw4bGkjsZ6R0gPTGce/Pv2UH/3oRzgcDqsjiUS9Eypyv/vd7074Be+6665TDiMi8sknnwDgSz/b4iRyBLsdX3of6qq2sGbNGkaPHm11IpGod0JF7umnnz6hF7PZbCpyInLKampqWLFiJUZiFmZcitVx5Ch8GX2JrdrCRx99pCIn0g2cUJH78nVxIiJd4aOPPsI0A/iyBlgdRY4hkJhFIM7NgoUL+clPfkJSUpLVkUSimu4fF5FuwTRN3n//A7A78aX3sTqOHIvNhjdzAD6vl08//dTqNCJR75R2oi4vL2fu3Lns3r0br9fb6dhTTz0VkmAiEl3Wrl3Lnj3l+DL6gSPW6jjyFfyZ/WDPaubOncdVV13Vab9tETmzTrrI/etf/+Lqq6+mT58+FBUVMXToUHbu3IlpmowaNaorMopIFHjnnXcA8GYPsjiJHI8ZE48v9Sy2bSthy5YtWopExEInfWr1wQcfZObMmWzcuJG4uDj++c9/UlZWxqRJk/jOd77TFRlFJMLt37+fzz77DCMhg0BiltVx5AT4sgcDhwq4iFjjpIvcli1buPHGGwFwOp20tLSQlJTEL3/5Sx577LGQBxSRyDd37lwMw8CXPUhrx4UJIzmXQFwqn376KXV1dVbHEYlaJ13kEhMTaWtrAyA/P5/t27cHj9XU1IQumYhEhba2Nt56621MZxy+9L5Wx5ETZbPhzRmCz+fj7bfftjqNSNQ66SI3fvx4Fi9eDMCVV17JzJkz+fWvf80Pf/hDxo8fH/KAIhLZPvroIxoaPO3XxjlO6f4rsYgvox+mM4633nqb1tZWq+OIRKWTLnJPPfUU48aNA+Dhhx/m0ksv5a9//Su9evXixRdfDHlAEYlcfr+fv/71b2B3BK+5kjDicOLNHkRDg4cPPvjA6jQiUemki9yvfvUrqqurMU2ThIQEfv/737N+/XrefPNN7cMqIidl/vz57NlTjjdzAGZMvNVx5BT4soeAI4Y5c+YEL7sRkTPnpIvc/v37ufLKK+nZsyczZ85k7dq1XRBLRCKd1+vlpZdeArsTb94Iq+PIKTJj4mjLOYfa2lreeustq+OIRJ2TLnJz586lsrKSX/ziF6xevZrCwkKGDBnCrFmz2LlzZxdEFJFING/ePKqqqvBmD8aMTbA6jpwGb85QcLr4y2uv0djYaHUckahySlt0paamcuutt7JgwQJ27drFTTfdxJw5c+jXr1+o84lIBKqpqWm/ptbpoi1vmNVx5HQ5Y2nNG05jQwP/93//Z3UakahyWnut+nw+Vq1axfLly9m5cyc5OTmhyiUiEeyZZ56hubmZ1p5jwBlndRwJAV/2ORjxacydO5cNGzZYHUckapxSkfv3v//NLbfcQk5ODjfeeCPJycnMmzePsrKyUOcTkQizePFiFi5ciD85F19mf6vjSKjY7bT2Ph+A//f//t8R+3CLSNc46SLXs2dPrrjiCqqrq3n++efZt28fL730Epdccgl2+2lN8IlIhKusrOQ3jz0GdgdtvSZqF4cIE0jKwps9hF27dvHss89aHUckKpz06psPPfQQ3/nOd0hLS+uKPCISodra2njooYdobGigpff5BOJTrY4kXaCtYDSOA/uYO3cugwcP5vLLL7c6kkhEO+kptFtvvVUlTkROimma/O53v6O4uBhv1gD8WQOsjiRdxe6kpd9F4HTx1FNPUVxcbHUikYimc6Ei0uVeeukl3nvvPYzETNrOmmB1HOlipiuZ5rMn4fP5uP+BB9i1a5fVkUQiloqciHSpV155hVdffZVAXAot/S4Bu8PqSHIGGO6etPaaSH1dHXfffbduhhPpIipyItJl5syZw0svvUQgLoXmgZdr4d8o48seRGuvCdTW1jJjxgzKy8utjiQScVTkRCTk/H4/zzzzDC+++CIBV/LBEpdodSyxgC97MK1njWf//v3cceedWmNOJMRU5EQkpOrr67nvvvv45z//SSA+TSVO8OUMaT/NWu9hxoy7mTdvntWRRCKGipyIhExJSQm33nYba9aswZfWm6bB0zBdSVbHkm7Alz2I5gGX4bc7efLJJ3nyySfx+XxWxxIJeypyInLaDMPgn//8Jz/+8R1U7dtHW89CWvteCI4Yq6NJN2Kk5NE0+GqMhAzmzZvHnXfeyc6dO62OJRLWbKZpmlaHCAcNDQ243W48Hg8pKSlWxxHpNnbu3MkTTzzBpk2bMJ1xtPT5GkZqgdWxpDsL+InbtZSYmhIcTiffnz6d66+/npgYFX+RDifaO1TkTpCKnEhnPp+P119/nVdffRW/348v/WzazhqHGRNvdTQJE476MuJ3LcHmbaJ3nz48cP/9DB482OpYIt2CilyIqciJHLJq1Sqee+73lJbuwIxNpKXXRM3CyakxfLjKVxFbtQWbzc43vnEN06dP1w5CEvVU5EJMRU4EtmzZwgsvvMCaNWsA8GYNoq1gNDhiLU4m4c7RWEnczsXYWz3Excdz3bXXcu2115KYqDueJTqpyIWYipxEs507d/Liiy/y2WefAeB3F9DWs5BAQrrFySSiBALE1BTj2rsWm6+Z5JQUpt9wA1//+tdxuVxWpxM5o1TkQkxFTqLR7t27ee211/joo48xzQD+pBy8PUdjJOdYHU0imeEntmozrsr14PeSmZnF978/ncsuu0yFTqKGilyIqchJtDBNk9WrV/OPf/yDZcuWAWAkpNPWoxDD3RNsNosTStTwtxFbuQHXvs0Q8JOS4ubrX7+aa665hoyMDKvTiXQpFbkQU5GTSNfW1sYnn3zCP/7xD0pLSwHwJ+fiyzkHf+pZKnBiGZuvhZiqLcRWbcXmb8XhdHLJxRfz7W9/m/79+1sdT6RLqMiFmIqcRKr9+/czd+5c3n77HTyeerDZ8aX3wZtzDoHETKvjiRwS8BOzfzux+zZhb6kH4Nxzz+Xb3/4248ePx+l0WptPJIRU5EJMRU4iidfrZcmSJXz44YcsX74C0wxgOuPwZg3Elz0YMzbB6ogix2aaOBr2ErtvI07PHgDS09O57LLLmDp1Kr169bI4oMjpU5ELMRU5CXemaVJSUsKHH37I/PnzaWxsBMBIzMaX1R9fel9waEZDwou9pZ6Yqq3E1O7A5m8FYPDgwVx++eVcdNFFJCVpr18JTypyIaYiJ+Gqvr6e+fPn88EHH7Bjxw4AzJgEvBl98Wf2JxCfam1AkVAIGDjry4ipKcHZUA6mSUxsLJMuuICpU6cycuRIHA6H1SlFTpiKXIipyEk48Xg8fP755yxYsIDVq1cTCATar31LPQtfZn8Mdw+w2a2OKdIlbN5mnPu3E1tTgr21HoD09AwmT57E5MmTGTp0KHa7/vuX7k1FLsRU5KS783g8fPbZZyxcuPBQeQOMxCx8GX3xZZwNzjiLU4qcQaaJvamamJptxNTtDJ56TU/PYNKkC7jwwgtV6qTbUpELMRU56Y6+sryl98Gf1hvTpWuERDADOBorcdaWElO364hS1zFTp9Ov0l2oyIWYipx0F3v37mXJkiUsWbKEtWvXqryJnKxjlLq09HTOP+88JkyYQGFhoXaREEuFRZFbtGgRTzzxBKtXr6aiooK33nqLa665JnjcNE0eeeQRXnjhBerq6hg3bhzPPfcc55xzTnBMW1sb9957L6+//jotLS1cfPHF/P73v6dnz57BMXV1ddx1113MnTsXgKuvvppnnnmG1NTUE86qIidWMQyDLVu2BMvbzp07Dx1TeRM5PYeXuvrd2HwtAMTGuhg9upCJEycyYcIE7SQhZ9yJ9g5L1xpoampixIgR3HTTTXzrW9864vjjjz/OU089xcsvv8yAAQN49NFHufTSSykqKiI5ORmAGTNmMG/ePN544w0yMjKYOXMm06ZNY/Xq1cEp8uuvv57y8nI+/PBDAG699VamT5/OvHnzztybFTkJzc3NrFq1isWLF7Ns2fL2hXoB7E58qWdhpJ6FP7UnZozWexM5LTY7Rko+Rko+beZE7E3VOOt3Y9SXBf94Ahg0aFCw1PXr1w+bdjqRbqLbnFq12WydZuRM0yQ/P58ZM2bwwAMPAO2zbzk5OTz22GPcdttteDwesrKymDNnDtdddx3QftqpoKCA999/n8suu4wtW7YwZMgQli1bxrhx4wBYtmwZEyZMYOvWrQwcOPCE8mlGTrqSaZqUl5ezYsUKli1bxpo1a/D7/e3HYhPwuc/Cn1qAkZIHdq31JnIm2NoacdaX4azfjbOxEsz2yxiysrKZOHECY8eOZeTIkSQk6A8qCb2wmJH7KqWlpVRWVjJlypTgcy6Xi0mTJrFkyRJuu+02Vq9ejc/n6zQmPz+foUOHsmTJEi677DKWLl2K2+0OljiA8ePH43a7WbJkyQkXOZFQa25u5osvvmDFihWsWLGCysrK4DEjIQN/dnt5CyRkaJ9TEQuYrmR8OUPw5QwBw4vTswdn/W6q6sp55513eOedd3A4nQwbOpSxY8cyduxY+vbtq9k6OaO6bZHr+KWWk5PT6fmcnBx27doVHBMbG0taWtoRYzo+v7Kykuzs7CNePzs7u9Mvzi9ra2ujra0t+HFDQ8OpvRGRgwKBANu3bw8Wt40bN2IYBgCm04U/vQ9+d0+MlB7aIkuku3HEtv8/mt4HzAD2phqcnnKcnj2sXbuWtWvX8sILL5CWns7YMWMYO3Yso0ePxu12W51cIly3LXIdvvyXjWmax/1r58tjjjb+eK8ze/ZsHnnkkZNMK9JZbW0tX3zxBStXrmTFihXU1dUdPGLDSMzE7+6J392jfXN6LdArEh5sdgJJ2XiTsvH2GAX+VpyevTgb9lDrKeejjz7io48+wmazMXDgQMaNG0dhYSFDhgzB6ez2v3YlzHTb/6Jyc3OB9hm1vLy84PNVVVXBWbrc3Fy8Xi91dXWdZuWqqqqYOHFicMy+ffuOeP3q6uojZvsO9+CDD3LPPfcEP25oaKCgoOD03pREvObmZtavX8/q1atZvXp1cEssaN8Wy5/ZH7+7B/6UHuDU0gYiEcEZhz/jbPwZZ7cvQtxSh9NTjsOzh61FxWzdupVXXnmFuPh4Rp57LoWFhRQWFtK7d2+dhpXT1m2LXJ8+fcjNzWX+/PmMHDkSAK/Xy8KFC3nssccAKCwsJCYmhvnz53PttdcCUFFRwcaNG3n88ccBmDBhAh6PhxUrVjB27FgAli9fjsfjCZa9o3G5XFpDSI7L7/dTVFQULG4bN23COHiTAnZn+4zbwTviAvFputZNJNLZbAQS0vEmpEPecDB8OBorcHr2YjTuZenSpSxduhRoX7du9MFSN2rUqKNeBiRyPJYWuQMHDrBt27bgx6Wlpaxdu5b09HTOOussZsyYwaxZs+jfvz/9+/dn1qxZJCQkcP311wPgdru5+eabmTlzJhkZGaSnp3PvvfcybNgwLrnkEgAGDx7M1KlTueWWW3j++eeB9uVHpk2bphsd5KSZpsnu3buDxW3NmjU0NzcfPHrwdGlWe3EzkrLBrlXiRaKaIwbj4JJB0L4PrKNhL86GvdQ27GX+/PnMnz8fgLPOOis4W3fuueeSlKS1IeX4LF1+ZMGCBVx44YVHPH/jjTfy8ssvBxcEfv755zstCDx06NDg2NbWVu677z5ee+21TgsCH34atLa29ogFgZ999lktCCwnpKKigjVr1vDFF1/wxRdrqK3dHzwWiHMHZ9z8yXngjLUwqYiEFdPE3urB0bAXR8NeYhorwPABYLPZGThwAKNGjWLUqFEMHTqUuDjtlRxNwmJnh3CiIhc9amtrDytuX1BRURE8ZsYk4E/JC5Y3MzbRwqQiElECAezNNTg9e9pPxx6oCq5d53Q6OeeccygsLGTkyJEMHjxYN05EOBW5EFORi1yNjY2sW7cuWNwO3wLLdLrwJ+dhpOThT87HjEvRdW4icmYYfhwH9uFoqMDZuBdH036g/Vd2XFwcI0aMYOTIkRQWFtK3b1/sdt35HklU5EJMRS5ytLS0sHHjRr744gvWrFlDUVEx5sG/enHE4E/KwZ+Sd/AGhXQVNxHpHvxtOBr34WzYi6OxAkdLXfBQcnIyI0eOZNSoUYwcOZKzzjpLd8SGORW5EFORC18+n48tW7YEi1unO0ttdvxJ2cFr3AKJWaC/akUkDNh8LTgaKnA07sXZUIG9rTF4LCMjI3h93ciRI4NLekn4UJELMRW58GEYBtu2bQueKl2/fv1hu3QcvLP04Ixb+52lus5ERMKfre1A+x2xjRU4Gyqw+ZqDx/Lz84OlbtSoUUfsiCTdj4pciKnIdV+mabJnzx5WrVp1cEmQtRw4cOgvUyM+rX3GLSUPIylXd5aKSOTruCO2seJguavE5j+07WSfPn0YNWoUo0ePZsSIESQkaFvA7kZFLsRU5LqX+vr64Fpuq1atoqqqKngs4Eo+eFdpHkZyHmZMvIVJRUS6AdPE3lx7aMausRIC7ZeYOByO4B2xo0ePZuDAgbojthtQkQsxFTlrtba2smHDhuCs2+ELSZvOuIOnSnvgT8nHdGkRTRGRrxQwcDRVtxc7z14czdVwsA4kJCQE74YdPXo0BQUFunHCAipyIaYid2aZpsmOHTtYtmwZq1evZv369fiDW1858Cflts+6uXVnqYjIafN7cXachm3Yi73VEzyUmZXF6MJCxo4dy5gxY0hOTrYwaPRQkQsxFbmu19TUxOrVq1m2bBkrVqygpqYmeMxIyMTvztcNCiIiZ4Ct7cDBPWL34GyswOZraX/eZuecc4Ywbtw4xo8fT79+/TRb10VU5EJMRS70TNOktLSU5cuXs3z5cjZs2IBhGO3HYuLxp/Ro33Te3QOcLovTiohEKdPE3lLbvuOEpxzngX3B07Bp6emMHzeOcePGUVhYqNm6EFKRCzEVudBoa2tj5cqVLF++nKXLllFTXR08ZiRm4U8twO/uSSAhQ6dLRUS6I38bzoa9OD3lOD3lwdk6u93O0KFDGTduHBMnTqR3796arTsNKnIhpiJ36pqbm1m6dCmLFi1i2bJlwTXdTGccfnf7rJuR0gMzRhtCi4iElYN3wzo9ZQdn66rp2EasoKCASZMmccEFF9C/f3+VupOkIhdiKnInp7GxkSVLlrBo0SJWrFiBz+cDIBDnxpfWC39qLwKJGWDTLgoiIhHD39Y+U1e3ixhPeXCJk9zcXC644AImTZrE4MGDtS/sCVCRCzEVueOrr6/n888/Z+HChXzxxRfB692M+DT8ab3xp/cmEK/VxEVEokLA336zRN1OYurLwPACkJmZyde+9jUuuOAChg8fjsPhsDho96QiF2IqckdnGAarVq3ivffeY/HixYfKW2Im/rTe+NJ6Y8bp+yUiEtUCRvvSJnW7iKnfFdxlIisrmyuuuJwrrriCnJwci0N2LypyIaYi11lVVRUffPAB7733XnBXBSMhA19GP/xpvbQor4iIHJ0ZwNFYibN2J7G1O8DwYrPZGDt2LNOmTWPChAnaWQIVuZBTkQO/38+yZct49913Wb58BaYZAEcM3vS++LIGEEjMtDqiiIiEE8OPs66UmOoinAfaJwXS0tO5fOpUrrzySnr06GFxQOuoyIVYNBc5v9/Pe++9x6tz5rD/4CK9RlI23qyB+NN6gyPG2oAiIhL27C11xFQXE7N/OzZ/KwDjx4/nlltuoW/fvhanO/NU5EIsGotcIBBg4cKF/N8f/8jePXvaZ98yB7TPvummBRER6QoBo/1auuqtOBsrsdlsXHrppdx0003k5eVZne6MUZELsWgrcqtXr+aFF16gqKgIbHa82YPx5g3HjIm3OpqIiEQJh2cPrvJVOJr343Q6ueaaa7jhhhtITU21OlqXU5ELsWgpcnV1dcyaNYuVK1cC4MvoS1uPUZgubbsiIiIWME2ctaW49nyBva2BhIQEbr31Vq655hqrk3WpE+0dui1Egvbt28fMmTMpLy/Hn9KDtoLR7VtliYiIWMVmw59xNv60XsRUF2FWrOV//ud/qKmp4eabb476HSNU5ASAXbt2MXPmvdTUVNOWfy7e/JHa61RERLoPuwNfzhD8qWeRUPwRf/7znzlw4AB33XVXVO8UEb3vXIK2bdvGnXfeRU1NNa0FY/H2GKUSJyIi3ZLpSqJ50BUYCRm8/fbbzJo1i0AgYHUsy6jICS+88AINDR5aep+PL3eo1XFERES+khkTT/PAy/En5fDJJ5/wxRdfWB3JMipyUS4QCLBp0yaMuFT8WQOsjiMiInJinLF484YDsHHjRovDWEdFLsrt2rWLpqYmjKQsq6OIiIicFCMpG4BNmzZZnMQ6KnJRbvfu3QBaH05ERMKP3YHpiA3+LotGKnJRbsSIEaSkuHHt24ytrdHqOCIiIicsds8abIaXyZMnWx3FMipyUS41NZWf/OQuCPiJ27kYtD60iIiEAXtTDa59G8nv0YObbrrJ6jiWUZETLrroIs477zycDXtx7VoChs/qSCIiIsdkb9xH/PZ/g2ly/333ERcXZ3Uky2hBYMFms3HPPfdQUVHBjh1FxDTsoaX31zBSomdzYhERCQMBP67yL4jdtxGbzc7N//mfnHvuuVanspRm5ASAjIwMnn/+eW688Uac/hYSij7Q7JyIiHQb9sZ9JG56h9h9GykoKODZZ5/hhhtusDqW5WymqYuiTsSJbl4bCUpKSpg1azalpTswXUm05Q7Dl9EPHDFWRxMRkShjb6kjpnITsTXF2Gx2rrvuWm666SZcLpfV0brUifYOFbkTFE1FDsDn8zFnzhxee+01/H4/pjMWb+ZAfNmDMV1JVscTEZFIZpo4POXE7tuEs2EvAL169eL+++/nnHPOsTjcmaEiF2LRVuQ61NXVMW/ePN56+23qamvBZsOX2htv7jkEErO0J6uIiISO4SOmpoTYqs3YWxsAKCws5Nvf/jbjxo3Dbo+eK8JU5EIsWotcB6/Xy4IFC/j73/9OSUkJAEZiJr6sgfhTe2HGRO8dQyIichpME3tTDTG1O4itKQHDS0xsLJdNmcI3v/lNzj77bKsTWkJFLsSivch1ME2TDRs28I9//IPPPvsc0wyAzYY/OQ9/eh+VOhEROb6O8lZXirNuJ/a2A0D7jXff+MY3mDZtGqmpqdZmtJiKXIipyB2pqqqKhQsXsmDBgkP73KnUiYjI0RyjvCUmJnL++eczefJkRo8eTUyMbqwDFbmQU5H7al9Z6tJ6408twIxNtDakiIicWWYAx4FqnPW7jlreLrzwQgoLC1XejkJFLsRU5E7cUUsdYMSnYqT0wO/ugZGUCw6tRy0iEmlsbY04PXtwePYQ01gBhheAxKQkvnZw5k3l7fhU5EJMRe7UVFVVsXjxYlauXMkXa9bQ2tLSfsDuwJ+Ugz+lB4a7B4H4NN0BKyISjgwfjsYKnJ49OD17sLc1BA/17NmTsWPHMm7cOEaNGqXydhJU5EJMRe70+Xw+Nm3axMqVK1m5ciXFxcXBY2ZMAv6U/PbZupR8zJh4C5OKiMgxmQHszbXts24Ne3AeqAIzALSfMi0sLGTMmDGMHj2avDxt9XiqVORCTEUu9Orr61m9ejUrVqxg5cpV1NbuDx4LxLnxJ+diJOdiJOVoEWIREasEDOzN+3E2VuJorMRxoArbwdOlNpudwYMHMWbMGMaMGcOgQYNwOnXZTCioyIWYilzXMk2T0tJSVqxYwdq1a9mwYQNNTU3B44HYJIzkHIzkXPxJuZhxKToVKyLSFQwfjqbq9tLWuA9nUzUE/MHDZ511FiNGjKCwsJBRo0bpd2IXUZELMRW5M8swDHbs2MH69etZv34969ato76+PnjcjInHn5TTXu6ScgkkpIEtelb8FhEJGX8bjgP7cDbuay9vzfuDp0ptNjv9+vVl+PDhjBgxgmHDhpGWlmZx4OigIhdiKnLWMk2TsrKyTsVu3759h447YjESMzGSsjESszCSssCpNexERDoxTeyt9TgOVGM/UNU+89ZSFzzscDoZPGgQI0aMYPjw4ZxzzjkkJenSFiuoyIWYilz3s2/fvmCxW79+Pbt27ep0POBKwUjKCpa7QHw6RNE+fSIiNl8r9qZqHB2lrakmeH0bQHx8AkOGDA7Otg0ZMgSXy2VhYumgIhdiKnLdX2NjI0VFRWzevJnNmzezadMmGhsbDw2wO/EnZBAIztplY8YmWBdYRCSUAgHsLbWHStuB6k5LgdhsNnr16sWQIUOCj169euFwOCwMLceiIhdiKnLhxzRN9uzZ06nYbd++nUAgEBwTiE1sn61LzGw/NZuQCc5YC1OLiJwA08TW1oCjqQZHUw32phqczTUQMIJDUlJSOpW2QYMG6TRpGFGRCzEVucjQ2tpKcXFxsNxt3Lip07InAIG4FIyELIzEzPaCl5AODi1iKSIWMU1s3qZgYXM0V+No2t/pFKnD4aBv376diluPHj2w6e7+sKUiF2IqcpHJNE1qamrYunUrRUVFFBUVsXXr1s6nZLFhxKd2mrULJKSDXacjRCT0bL7m9sJ22MPmbz103GbjrLPOYuDAgQwaNIiBAwfSr18/XdsWYVTkQkxFLnqYpklFRUWw3G3dupWi4uJD24sB2OwY8emHzdpltG8zppspROQk2Hyt2JtrcDTtPzjbVoPd29RpTF5eXrCwDRo0iP79+5OYmGhRYjlTVORCTEUuugUCAcrKyoLFbuvWrZRs24bPe+jUxqFyl/GlcqeZOxEBm6/lYFnbf+ifXyptmVlZDDpspm3gwIH6nROlVORCTEVOvszv91NaWkpxcXHwsW3bNnw+36FBNjtGfFr7zF1CRvs/Ve5EIt6JlLaMjAwGDhzIgAEDGDBgAAMHDiQjI8OixNLdqMiFmIqcnAi/38/OnTuPKHfeI2bu0tpn7Dpm7hLSwK79CUXCkc3bfOj0aPN+nM012LzNncZkZmUx8GBh63iotMlXUZELMRU5OVV+v5/du3dTVFQULHcl27bhbWs7NMhmx4hPbb+RIjHjYLlLV7kT6WYOlbb24uZo3o/N17m0ZWVlM3DgoVm2/v37k56eblFiCVcqciGmIieh1FHuiouLKSkpoaioiJKSEto6lTsbRlxqcNau/fSsyp3IGWGa2HzN7Ut+NO9vL27N+7H5WjoNy8nJCZa1juKWmppqTWaJKCpyIaYiJ13NMAzKysooLi4Ozt6VlJTQ2npo2YFguTtY7Npn7jLAoXIncso61mlrrsF+cJbtaKUtNzc3WNYGDBhA//79Vdqky0REkXv44Yd55JFHOj2Xk5NDZWUl0L5MxCOPPMILL7xAXV0d48aN47nnnuOcc84Jjm9ra+Pee+/l9ddfp6WlhYsvvpjf//739OzZ86SyqMiJFQzDoLy8vNM1d8XFJbS0HH4qR+vciZyMI9ZpO0ppy8vL63QjQv/+/XG73RYllmh0or2j2/8Zf8455/DJJ58EPz58T7jHH3+cp556ipdffpkBAwbw6KOPcumll1JUVERycjIAM2bMYN68ebzxxhtkZGQwc+ZMpk2bxurVq7W/nHR7DoeDXr160atXLy699FKgfSmU8vLy4CnZoqKi9nXuakqIqSlp/8Tg3bKHth8LxKeCTevcSZTxtx22jVX1Ue8ebV+nbXynGxE6foeIdHfdfkbu7bffZu3atUccM02T/Px8ZsyYwQMPPAC0z77l5OTw2GOPcdttt+HxeMjKymLOnDlcd911AOzdu5eCggLef/99LrvsshPOohk56c6+vM5dxzV3ne6WtTsxEtIxEjKDCxkH4tygLXwkUhi+w7axOlje2ho7DdE6bRIuImZGrqSkhPz8fFwuF+PGjWPWrFmcffbZlJaWUllZyZQpU4JjXS4XkyZNYsmSJdx2222sXr0an8/XaUx+fj5Dhw5lyZIlX1nk2traOl143tDQ0DVvUCQE7HZ7cOau47/3jqVQDt9+bPuOHRgHqg59oiMGf0ImRlIWRlI2gcQszJh4i96FyEkwA9hb6nEcqMLRVI39QDWO1vpOQ9zuVAaPHB8sbFqnTSJRty5y48aN49VXX2XAgAHs27ePRx99lIkTJ7Jp06bgdXI5OTmdPicnJ4ddu3YBUFlZSWxsLGlpaUeM6fj8Y5k9e/YR1+eJhBOn00m/fv3o168f06ZNA9r/QCktLe20/djOnTtxNlYEPy/gSsZIbC92RlK2FjCWbsHma2kva01VOA5U42yuAePQ4tuJiYkMKiwMFrZBgwaRnZ2tTeMl4nXrInf55ZcH/33YsGFMmDCBvn378sorrzB+/HiAI/4nNU3zuP/jnsiYBx98kHvuuSf4cUNDAwUFBSf7FkS6FZfLxaBBgxg0aFDwuaamJoqKiti8eTObN29m46ZNNNTuIKZ2R/sAuwN/QgaBxOzgzJ0Zq30epQsFDOzNtTiaqg/NuB12itRms9OnT2/OOecchgwZwpAhQygoKMCuvY4lCnXrIvdliYmJDBs2jJKSEq655hqgfdYtLy8vOKaqqio4S5ebm4vX66Wurq7TrFxVVRUTJ078yq/lcrlwuVyhfxMi3UxiYiKjRo1i1KhRQPsfOhUVFcFit2nTJrZt29Z+SnZf++eYsQn4E7MxknIwknPa75LVjRRyqvxtOA7sw9lY2V7cmvdDwAgedrtTOadwYrC4DRw4kISEBAsDi3QfYVXk2tra2LJlC1/72tfo06cPubm5zJ8/n5EjRwLg9XpZuHAhjz32GACFhYXExMQwf/58rr32WgAqKirYuHEjjz/+uGXvQ6Q7s9ls5Ofnk5+fzyWXXAK0/79XXFx8qNxt3kxN9U5i6na2f5IjFn9SNkZyDv6kXAKJmTodK8dk8zXjaKzE0biv/Z8tdcFjDoeD/gP6B2fahgwZQl5enk6RihxDty5y9957L1dddRVnnXUWVVVVPProozQ0NHDjjTdis9mYMWMGs2bNon///vTv359Zs2aRkJDA9ddfD4Db7ebmm29m5syZZGRkkJ6ezr333suwYcOCv6BE5PhcLhfDhg1j2LBhweeqqqrYsGED69atY926dezatQunpxwXgN2JPzELIzkHIzkXIzFbixZHMVtbY7C4ORsrsbcdunksLi6OoaNHM3z4cEaMGMGgQYN0NkTkJHTrn6zl5eV897vfpaamhqysLMaPH8+yZcvo1asXAPfffz8tLS3cfvvtwQWBP/74407r/zz99NM4nU6uvfba4ILAL7/8staQEzlN2dnZXHzxxVx88cUA1NfXdyp227ZtP3QThc2OkZCJPzkHIyUPIzlXW41FMFvbAZwNe4Llze49EDyWmJTEiMKJweLWv39/nE79tyByqrr1OnLdidaREzk5Bw4cYNOmTaxbt47169ezZetWDL+//aDdgT8pF7+7B4a7B4G4VK1nF84MH47GSpyePTgb9mBv9QQPpaWlce655zJ8+HCGDx9Onz59dFOCyAmIiC26uhMVOZHT09rayubNm1m1ahUrV66kpKQkeMyMTcSXko/h7oE/pQc4dWqtWzNN7C21OD17cHj24DywD8wAAAkJCRQWFjJ69GgKCwvp0aOHrm8TOQUqciGmIicSWrW1tcFSt3LlSurr6w8esWEkZuI/WOoCSVm6I7Y78Le2z7gdnHXr2JvUZrMxcOBAxowZw5gxYxgyZIhOlYqEgIpciKnIiXSdQCDA9u3bg6Vu/YYNwdOwZkw8vtRe+NN7t19bp1J3xth8LTjrduGsK8XZWAkHf11kZGQwduxYxowZw6hRo0hNTbU2qEgEUpELMRU5kTOnubmZtWvXsnz5chYtWkRdXfvyFKbTdVipy9MSJ13A5m06WN52tpe3g4YOHcr555/P2LFj6dOnj06XinQxFbkQU5ETsYZhGGzatImFCxeycOFCampqADCdsfjdZ+FL742Rkq+7YE+Dra0RZ91OYmp34Whq34vXZrMzYsRwJk2axNe+9jUyMzMtTikSXVTkQkxFTsR6gUCALVu2sGjRIhYuXHhoz2RHLN70s/FlDWhfjFiOz/DjrCslproI54H28ma32xk1ahSTJk3i/PPPP2KfahE5c1TkQkxFTqR7MU2T4uJiFi1axCeffMK+fe37hxkJGfiyBuLLOBscsRan7H7szfuJqS4idv8OMLzYbHbGjBnNhRdeyMSJE3G73VZHFBFU5EJORU6k+zIMg9WrV/Puu++yePFiDMMAuxNfeh+8WQMJJGZF9zp1ho+Y/duJqS7G0dx+ajorK5srr7yCK664guzsbIsDisiXqciFmIqcSHiora3lo48+Yt6777J3zx4AjPhUvLnD8Kf3hShajNbW1khsxQZi92+DgB+73c7EiRO56qqrGD16tHa4EenGVORCTEVOJLyYpsnatWt59913WbhwIX6/n4ArCW/ucHyZ/SP6jldbqwdXxXpi9m8HM0Bubh5XXTWNqVOnkpGRYXU8ETkBKnIhpiInEr6qq6v561//yty58/B62zBjE2nLHYova2BE3e1qb6kjdu86YmpLAZPevXszffp0Jk+erNk3kTCjIhdiKnIi4a+2tpa///3vvPX227S2tGDGxNOWOwxf9uCwnqGztXhw7VlFTN0uAPr378/3v/99zjvvPO1rKhKmVORCTEVOJHJ4PB7efPNN/v6Pf9Dc1EQgLpXWXhMwUvKsjnZyDD+xFWtxVW4EM8CQIUP4/ve/z7hx47Rgr0iYU5ELMRU5kcjT2NjIn/70J95++x1MM4Av/WzaCsZixiZYHe2rmSbO+t3E7V6OzXuAnNxc7rrzTiZOnKgCJxIhVORCTEVOJHIVFxfz9NNPs2XLFnDE0po/El/O4G65r6utrZG4XctwespwOp1897vf5Xvf+x5xcXFWRxOREFKRCzEVOZHIFggEeP/993n++edpbGzEn5JP69mTMGPirY4W5KzdSfzOz8DwMXr0aH7yk59QUFBgdSwR6QIqciGmIicSHTweD0888QSff/45ZkwCLX0nYyTnWhsqYOAqX0nsvs244uKYec89XHrppTqNKhLBTrR3dL/zBiIiFnK73fzqV7/i9ttvxxloI6HoA2Ir1oNFf/Pa2g6QsPU9Yvdtpnfv3rzw/PNMmTJFJU5EABU5EZEj2Gw2rr32Wn7729+SmZGJq3wVcTsWQiBwRnPYm2pI3DwXR1MNU6dO5X//93/p1avXGc0gIt2bipyIyDEMHTqUP/7x/xg+fDgxtTuI2/4pBIwz8rXtjftILPoQu+Hlnnvu4ac//aluaBCRI6jIiYh8hdTUVB5//HFGjx5NTP1u4ks+AcPfpV/T0bCXxJKPcGDw0EM/5+qrr+7Sryci4UtFTkTkOOLi4pg1axbnn38+zoY9xJd83GUzc46GChJK5hNjt/GrX/2KCy+8sEu+johEBhU5EZETEBsby8MPP8yFF16Is7GSuF1LQn4DhK3VQ8L2T3HabcyePZuJEyeG9PVFJPKoyImInCCn08lPf/pThgwZQkxNCTGVG0P34v42Eko+AX8b999/P6NHjw7da4tIxFKRExE5CS6Xi0cffZSsrCziylfiqN99+i9qBojf/m/srR6+973vMWXKlNN/TRGJCipyIiInKT09ndmzZxMb6yK+9HNsvpbTer2YfZtxNuzlvPPO4+abbw5RShGJBipyIiKnoF+/fvzXf92Gzd+Ka9fSU75ezt5ST9ye1aSmpXH//fdjt+vHsoicOP3EEBE5Rddccw0jRowgpm4nztrSk38BM0Bc6WcQMLh35kzcbnfoQ4pIRFORExE5RXa7nQceeACXy0Vc2XIwfCf1+TE123A0VXPJJZdw/vnnd1FKEYlkKnIiIqchPz+f66+/Hpuvhdh9m078Ew0frr1f4IqL40c/+lHXBRSRiKYiJyJymr7zne+QmpaGq3LDCd/4ELtvEzZvM/9x3XVkZGR0cUIRiVQqciIipykhIYEf3nQTGD5iK9Yf/xP8XlyVG0lNS+O6667r+oAiErFU5EREQuCKK64gMyuL2Jpi8Hu/cmxMTTEYXv7juutISEg4QwlFJBKpyImIhIDT6eTb3/oWGD5iqovADBz9EfDj2reZuPh4rrzySqtji0iYc1odQEQkUlx55ZW8/MorUL6SuPKVXz32W98iOTn5DCUTkUilIiciEiLJycnM+MlP+Ne//vWV4+Lj47n++uvPUCoRiWQ20zzF5cijTENDA263G4/HQ0pKitVxREREJIKdaO/QNXIiIiIiYUpFTkRERCRMqciJiIiIhCkVOREREZEwpSInIiIiEqZU5ERERETClIqciIiISJhSkRMREREJUypyIiIiImFKRU5EREQkTKnIiYiIiIQpFTkRERGRMOW0OkC4ME0TaN/EVkRERKQrdfSNjv5xLCpyJ6ixsRGAgoICi5OIiIhItGhsbMTtdh/zuM08XtUTAAKBAHv37iU5ORmbzWZ1HBEJEw0NDRQUFFBWVkZKSorVcUQkTJimSWNjI/n5+djtx74STkVORKQLNTQ04Ha78Xg8KnIiEnK62UFEREQkTKnIiYiIiIQpFTkRkS7kcrn4xS9+gcvlsjqKiEQgXSMnIiIiEqY0IyciIiISplTkRERERMKUipyIiIhImFKRExEREQlTKnIiEvZ69+6NzWbr9OjZs2fIXv8HP/gB11xzTche73QsWLCg0/vMyMjgoosuYvHixZ3GPfzww9hsNv7rv/6r0/Nr167FZrOxc+fOI157ypQpOBwOli1b1pVvQURCSEVORCLCL3/5SyoqKoKPNWvWWB3pCIZhEAgEQvJaRUVFVFRUsGDBArKysrjyyiupqqrqNCYuLo4XX3yR4uLi477e7t27Wbp0KXfccQcvvvhiSDKKSNdTkRORbm/y5Mncdddd3H///aSnp5Obm8vDDz/caUxycjK5ubnBR1ZWFtC+X+Hjjz/O2WefTXx8PCNGjOAf//hH8PMMw+Dmm2+mT58+xMfHM3DgQH77298Gjz/88MO88sorvPPOO8FZsAULFgRnxurr64Njvzzb9fLLL5Oamsq7777LkCFDcLlc7Nq1C6/Xy/3330+PHj1ITExk3LhxLFiw4KS+J9nZ2eTm5jJs2DB+9rOf4fF4WL58eacxAwcO5MILL+RnP/vZcV/vpZdeYtq0afzoRz/ir3/9K01NTSeVR0SsoSInImHhlVdeITExkeXLl/P444/zy1/+kvnz5x/38372s5/x0ksv8Yc//IFNmzZx9913c8MNN7Bw4UIAAoEAPXv25G9/+xubN2/moYce4r//+7/529/+BsC9997Ltddey9SpU4OzfRMnTjzh3M3NzcyePZs//vGPbNq0iezsbG666SYWL17MG2+8wfr16/nOd77D1KlTKSkpOenvS3NzMy+99BIAMTExRxz/zW9+wz//+U9Wrlx5zNcwTZOXXnqJG264gUGDBjFgwIDg+xeRbs4UEenmJk2aZJ5//vmdnhszZoz5wAMPmKZpmr169TJjY2PNxMTE4OO3v/2teeDAATMuLs5csmRJp8+9+eabze9+97vH/Hq33367+a1vfSv48Y033mh+/etf7zTm3//+twmYdXV1wefWrFljAmZpaalpmqb50ksvmYC5du3a4Jht27aZNpvN3LNnT6fXu/jii80HH3zwuN+Ljq/b8T5tNpsJmIWFhabX6w2O+8UvfmGOGDHCNE3T/I//+A/zoosuOmpG0zTNjz/+2MzKyjJ9Pp9pmqb59NNPm+edd95xs4iI9ZxWlkgRkRM1fPjwTh/n5eV1uibsvvvu4wc/+EHw48zMTDZv3kxrayuXXnppp8/1er2MHDky+PH//u//8sc//pFdu3bR0tKC1+vl3HPPDUnu2NjYTtm/+OILTNNkwIABnca1tbWRkZFxwq/72WefkZiYyJo1a3jggQd4+eWXjzojB/Doo48yePBgPv74Y7Kzs484/uKLL3LdddfhdLb/Svjud7/LfffdR1FREQMHDjzhTCJy5qnIiUhY+HJJsdlsnW4cyMzMpF+/fp3GdBx/77336NGjR6djHXuf/u1vf+Puu+/mySefZMKECSQnJ/PEE08ccb3Zl9nt7VemmIftcujz+Y4YFx8fj81m65TJ4XCwevVqHA5Hp7FJSUlf+TUP16dPH1JTUxkwYACtra184xvfYOPGjUfd07Vv377ccsst/PSnPz3iRoba2lrefvttfD4ff/jDH4LPG4bBn/70Jx577LETziQiZ56KnIhErI4bDHbv3s2kSZOOOuazzz5j4sSJ3H777cHntm/f3mlMbGwshmF0eq7jZoqKigrS0tKA9psdjmfkyJEYhkFVVRVf+9rXTubtHNP06dP55S9/ye9//3vuvvvuo4556KGH6Nu3L2+88Uan5//yl7/Qs2dP3n777U7P/+tf/2L27Nn8+te/Ds7UiUj3o5sdRCRiJScnc++993L33XfzyiuvsH37dtasWcNzzz3HK6+8AkC/fv1YtWoVH330EcXFxfz85z8/4saA3r17s379eoqKiqipqcHn89GvXz8KCgp4+OGHKS4u5r333uPJJ588bqYBAwbwve99j+9///u8+eablJaWsnLlSh577DHef//9U3qfdrudGTNm8Jvf/Ibm5uajjsnJyeGee+7hd7/7XafnX3zxRb797W8zdOjQTo8f/vCH1NfX8957751SJhE5M1TkRCSi/epXv+Khhx5i9uzZDB48mMsuu4x58+bRp08fAP7rv/6Lb37zm1x33XWMGzeO/fv3d5qdA7jlllsYOHAgo0ePJisri8WLFxMTE8Prr7/O1q1bGTFiBI899hiPPvroCWV66aWX+P73v8/MmTMZOHAgV199NcuXL6egoOCU3+cPf/hDfD4fzz777DHH3HfffZ1O365evZp169bxrW9964ixycnJTJkyRWvKiXRzNvPwCzxEREREJGxoRk5EREQkTKnIiYh0I5dffjlJSUlHfcyaNcvqeCLSzejUqohIN7Jnzx5aWlqOeiw9PZ309PQznEhEujMVOREREZEwpVOrIiIiImFKRU5EREQkTKnIiYiIiIQpFTkRERGRMKUiJyIiIhKmVOREREREwpSKnIiIiEiYUpETERERCVP/H597Us0jr4zrAAAAAElFTkSuQmCC",
+      "text/plain": [
+       "<Figure size 804.6x480 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "sc.pl.violin(adata, ['nFeature_RNA'], stripplot = False)\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 98,
+   "id": "62fdcff4-a376-465a-a3d2-a899665b01e4",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAnsAAAGKCAYAAAB0Eoe2AAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjguNCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8fJSN1AAAACXBIWXMAAA9hAAAPYQGoP6dpAAA75klEQVR4nO3deXxU9b3/8fcsmck2GcKShEhUKhHBuLRgAekVLIsLSG0ft7bF5mprsRaFUuFiqW2R9ha8YLX1R21pxdriEm+Lti40hXorFtlToyAu7S2QgAkJkEz2mcnM9/dHyJjJAknIZIbJ6/l4nMfMnPOZM5/hock733O+51iMMUYAAACIS9ZoNwAAAIDIIewBAADEMcIeAABAHCPsAQAAxDHCHgAAQBwj7AEAAMQxwh4AAEAcI+wBAADEMXu0G4gnwWBQH374oVwulywWS7TbAQAAccwYo9raWmVnZ8tq7Xr8jrDXhz788EPl5OREuw0AADCAlJaWasSIEV1uJ+z1IZfLJanlHz0tLS3K3QAAgHhWU1OjnJycUP7oCmGvD7Ueuk1LSyPsAQCAfnGmU8eYoAEAABDHCHsAAABxjLAHAAAQxwh7AAAAcYywBwAAEMcIewAAAHGMsAcAABDHCHsAAABxjLAHAAAQxwh7AAAAcYywBwAAEMcIewAAAHGMsAcAUbZv3z699NJL0W4DQJyyR7sBABjoFi5cKGOMpk2bpuTk5Gi3AyDOMLIHAFFmjAl7BIC+RNgDgBhhsVii3QKAOETYA4AYQdgDEAmEPQCIEYQ9AJFA2AMAAIhjhD0AiBFM0AAQCYQ9AIgRHMYFEAmEPQAAgDhG2AMAAIhjhD0AAIA4RtgDAACIY4Q9AACAOEbYAwAAiGOEPQAAgDhG2AMAAIhjhD0AAIA4RtgDAACIY4Q9AACAOEbYAwAAiGOEPQAAgDhG2AMAAIhjhD0AAIA4FjNhb9WqVbJYLFq0aFFonTFGDzzwgLKzs5WUlKSpU6fqnXfeCXuf1+vVggULNHToUKWkpGjOnDk6cuRIWE1VVZXy8/PldrvldruVn5+v6urqsJqSkhLddNNNSklJ0dChQ7Vw4UL5fL5IfV0AAIB+ERNhb8+ePfrlL3+pyy+/PGz96tWr9fDDD2vt2rXas2ePsrKyNGPGDNXW1oZqFi1apBdeeEEFBQXatm2b6urqNHv2bAUCgVDN3LlzVVxcrMLCQhUWFqq4uFj5+fmh7YFAQLNmzVJ9fb22bdumgoICbdy4UYsXL478lwcAAIgkE2W1tbUmNzfXbNmyxUyZMsV885vfNMYYEwwGTVZWlnnwwQdDtU1NTcbtdptf/OIXxhhjqqurTUJCgikoKAjVHD161FitVlNYWGiMMebAgQNGktm5c2eoZseOHUaSee+994wxxmzatMlYrVZz9OjRUM2zzz5rnE6n8Xg83f4uHo/HSOrRewBgypQpZsqUKaaxsTHarQA4h3Q3d0R9ZO/uu+/WrFmzNH369LD1Bw8eVHl5uWbOnBla53Q6NWXKFG3fvl2SVFRUJL/fH1aTnZ2tvLy8UM2OHTvkdrs1YcKEUM3EiRPldrvDavLy8pSdnR2que666+T1elVUVNRl716vVzU1NWELAABALLFH88MLCgr097//XXv27Omwrby8XJKUmZkZtj4zM1OHDx8O1TgcDqWnp3eoaX1/eXm5MjIyOuw/IyMjrKb956Snp8vhcIRqOrNq1SqtWLHiTF8TAAAgaqI2sldaWqpvfvObeuqpp5SYmNhlncViCXttjOmwrr32NZ3V96amvWXLlsnj8YSW0tLS0/YFAADQ36IW9oqKilRRUaFx48bJbrfLbrdr69atevTRR2W320Mjbe1H1ioqKkLbsrKy5PP5VFVVddqaY8eOdfj8ysrKsJr2n1NVVSW/399hxK8tp9OptLS0sAUAACCWRC3sTZs2Tfv27VNxcXFoGT9+vG699VYVFxfrYx/7mLKysrRly5bQe3w+n7Zu3aqrr75akjRu3DglJCSE1ZSVlWn//v2hmkmTJsnj8Wj37t2hml27dsnj8YTV7N+/X2VlZaGazZs3y+l0aty4cRH9dwAAAIikqJ2z53K5lJeXF7YuJSVFQ4YMCa1ftGiRVq5cqdzcXOXm5mrlypVKTk7W3LlzJUlut1t33HGHFi9erCFDhmjw4MFasmSJLrvsstCEjzFjxuj666/XvHnztG7dOknSnXfeqdmzZ2v06NGSpJkzZ2rs2LHKz8/XmjVrdPLkSS1ZskTz5s1jtA4AAJzTojpB40yWLl2qxsZGzZ8/X1VVVZowYYI2b94sl8sVqnnkkUdkt9t1yy23qLGxUdOmTdOTTz4pm80Wqnn66ae1cOHC0KzdOXPmaO3ataHtNptNr7zyiubPn6/JkycrKSlJc+fO1UMPPdR/XxYAACACLMYYE+0m4kVNTY3cbrc8Hg8jggC6berUqZKkwsLC005YA4C2ups7on6dPQAAAEQOYQ8AACCOEfYAAADiGGEPAAAgjhH2AAAA4hhhDwAAII4R9gAAAOIYYQ8AACCOEfYAAADiGGEPAAAgjhH2AAAA4hhhDwAAII4R9gAAAOIYYQ8AACCOEfYAIEYYY6LdAoA4RNgDgBhhsVii3QKAOETYAwAAiGOEPQCIEcFgMNotAIhDhD0AAIA4RtgDgBjBBA0AkUDYA4AYwWFcAJFA2AMAAIhjhD0AiBE2my3aLQCIQ4Q9AIgRVis/kgH0PX6yAAAAxDHCHgDECO6gASASCHsAECO49AqASCDsAUCMIOwBiATCHgDECA7jAogEwh4AxAjCHoBIIOwBQIzgMC6ASCDsAQAAxDHCHgDECO6NCyASCHsAECMCgUC0WwAQhwh7AAAAcYywBwAxgnvjAogEfrIAQIzg0isAIoGwBwAAEMcIewAQIziMCyAS+MkCAAAQxwh7ABAjuIMGgEgg7AEAAMQxwh4AxAhG9gBEAmEPAGIEd9AAEAmEPQCIEVxnD0AkEPYAIEYQ9gBEAmEPAGIEYQ9AJBD2ACBGEPYARAJhDwBiBGEPQCQQ9gAAAOIYYQ8AYgQjewAigbAHAAAQxwh7ABAjuIMGgEgg7AFAjCDsAYgEwh4AxAjCHoBIIOwBQIwIBoPRbgFAHCLsAUCMYGQPQCQQ9gAgRnDpFQCRQNgDgBhhtfIjGUDf4ycLAABAHCPsAUCMYGQPQCTwkwUAACCORTXs/fznP9fll1+utLQ0paWladKkSfrTn/4U2m6M0QMPPKDs7GwlJSVp6tSpeuedd8L24fV6tWDBAg0dOlQpKSmaM2eOjhw5ElZTVVWl/Px8ud1uud1u5efnq7q6OqympKREN910k1JSUjR06FAtXLhQPp8vYt8dANpjNi6ASIhq2BsxYoQefPBB7d27V3v37tWnP/1pfeYznwkFutWrV+vhhx/W2rVrtWfPHmVlZWnGjBmqra0N7WPRokV64YUXVFBQoG3btqmurk6zZ89WIBAI1cydO1fFxcUqLCxUYWGhiouLlZ+fH9oeCAQ0a9Ys1dfXa9u2bSooKNDGjRu1ePHi/vvHADDgMRsXQESYGJOenm4ef/xxEwwGTVZWlnnwwQdD25qamozb7Ta/+MUvjDHGVFdXm4SEBFNQUBCqOXr0qLFaraawsNAYY8yBAweMJLNz585QzY4dO4wk89577xljjNm0aZOxWq3m6NGjoZpnn33WOJ1O4/F4ut27x+Mxknr0HgCYMmWKmTJlimlsbIx2KwDOId3NHTFzzl4gEFBBQYHq6+s1adIkHTx4UOXl5Zo5c2aoxul0asqUKdq+fbskqaioSH6/P6wmOztbeXl5oZodO3bI7XZrwoQJoZqJEyfK7XaH1eTl5Sk7OztUc91118nr9aqoqCii3xsAACCS7NFuYN++fZo0aZKampqUmpqqF154QWPHjg0FsczMzLD6zMxMHT58WJJUXl4uh8Oh9PT0DjXl5eWhmoyMjA6fm5GREVbT/nPS09PlcDhCNZ3xer3yer2h1zU1Nd392gAAAP0i6iN7o0ePVnFxsXbu3KlvfOMbuu2223TgwIHQ9vbnsBhjznheS/uazup7U9PeqlWrQpM+3G63cnJyTtsXAABAf4t62HM4HBo1apTGjx+vVatW6YorrtBPf/pTZWVlSVKHkbWKiorQKFxWVpZ8Pp+qqqpOW3Ps2LEOn1tZWRlW0/5zqqqq5Pf7O4z4tbVs2TJ5PJ7QUlpa2sNvDwAAEFlRD3vtGWPk9Xo1cuRIZWVlacuWLaFtPp9PW7du1dVXXy1JGjdunBISEsJqysrKtH///lDNpEmT5PF4tHv37lDNrl275PF4wmr279+vsrKyUM3mzZvldDo1bty4Lnt1Op2hy8a0LgAAALEkqufsfec739ENN9ygnJwc1dbWqqCgQK+99poKCwtlsVi0aNEirVy5Urm5ucrNzdXKlSuVnJysuXPnSpLcbrfuuOMOLV68WEOGDNHgwYO1ZMkSXXbZZZo+fbokacyYMbr++us1b948rVu3TpJ05513avbs2Ro9erQkaebMmRo7dqzy8/O1Zs0anTx5UkuWLNG8efMIcAAA4JwW1bB37Ngx5efnq6ysTG63W5dffrkKCws1Y8YMSdLSpUvV2Nio+fPnq6qqShMmTNDmzZvlcrlC+3jkkUdkt9t1yy23qLGxUdOmTdOTTz4pm80Wqnn66ae1cOHC0KzdOXPmaO3ataHtNptNr7zyiubPn6/JkycrKSlJc+fO1UMPPdRP/xIAAACRYTGGS7b3lZqaGrndbnk8HkYEAXTb1KlTJUl/+tOflJSUFN1mAJwzups7Yu6cPQAYqLiDBoBIIOwBAADEMcIeAMSIYDAY7RYAxCHCHgAAQBwj7AFAjGBkD0AkEPYAIEZwcQQAkUDYA4AYwWxcAJFA2AOAGEHYAxAJhD0AiBGEPQCRQNgDAACIY4Q9AACAOEbYA4AYwaVXAEQCYQ8AYgSXXgEQCYQ9AIgRTNAAEAmEPQCIEYQ9AJFA2AOAGEHYAxAJhD0AAIA4RtgDgBjByB6ASCDsAQAAxDHCHgAAQBwj7AFAjOA6ewAigbAHADGCO2gAiATCHgDECEb2AEQCYQ8AYoTVyo9kAH2PnywAECO49AqASCDsAUCMIOwBiATCHgDECMIegEgg7AEAAMQxwh4AxAhm4wKIBMIeAMQIDuMCiATCHgDECEb2AEQCYQ8AYgR30AAQCYQ9AACAOEbYAwAAiGOEPQCIEZyzByASeh32/vnPf+rPf/6zGhsbJfFDCgDOFvfGBRAJPf7JcuLECU2fPl0XX3yxbrzxRpWVlUmSvva1r2nx4sV93iAADBRcegVAJPQ47H3rW9+S3W5XSUmJkpOTQ+u/8IUvqLCwsE+bA4CBhLAHIBLsPX3D5s2b9ec//1kjRowIW5+bm6vDhw/3WWMAMNBwOgyASOjxyF59fX3YiF6r48ePy+l09klTAAAA6Bs9DnvXXHONfvvb34ZeWywWBYNBrVmzRtdee22fNgcAAwkXVQYQCT0+jLtmzRpNnTpVe/fulc/n09KlS/XOO+/o5MmTeuONNyLRIwAMCIQ9AJHQ45G9sWPH6u2339YnP/lJzZgxQ/X19frc5z6nN998UxdddFEkegSAASEQCES7BQBxqMcje5KUlZWlFStW9HUvADCgEfYAREKPw97rr79+2u3XXHNNr5sBgIGMsAcgEnoc9qZOndphXdtrQ/HDCgB6x2azRbsFAHGox+fsVVVVhS0VFRUqLCzUVVddpc2bN0eiRwAYEAh7ACKhxyN7bre7w7oZM2bI6XTqW9/6loqKivqkMQAYaAh7ACKhz+66PWzYML3//vt9tTsAGHAIewAioccje2+//XbYa2OMysrK9OCDD+qKK67os8YAAABw9noc9q688kpZLJYO93CcOHGinnjiiT5rDAAGmraT3QCgr/Q47B08eDDstdVq1bBhw5SYmNhnTQHAQNT+j2gA6As9DnsXXHBBJPoAgAGPsAcgEroV9h599NFu73DhwoW9bgYABjLujQsgEroV9h555JFu7cxisRD2AKCXGNkDEAndCnvtz9MDAPQ9JmgAiIQ+u84eAAAAYk+PJ2hI0pEjR/Tiiy+qpKREPp8vbNvDDz/cJ40BAADg7PU47L366quaM2eORo4cqffff195eXk6dOiQjDH6xCc+EYkeAQAA0Es9Poy7bNkyLV68WPv371diYqI2btyo0tJSTZkyRZ///Ocj0SMAAAB6qcdh791339Vtt90mSbLb7WpsbFRqaqp+8IMf6L//+7/7vEEAGCiYjQsgEnoc9lJSUuT1eiVJ2dnZ+r//+7/QtuPHj/ddZwAwwBD2AERCj8/Zmzhxot544w2NHTtWs2bN0uLFi7Vv3z49//zzmjhxYiR6BIABgbAHIBJ6PLL38MMPa8KECZKkBx54QDNmzNBzzz2nCy64QOvXr+/RvlatWqWrrrpKLpdLGRkZuvnmm/X++++H1Rhj9MADDyg7O1tJSUmaOnWq3nnnnbAar9erBQsWaOjQoUpJSdGcOXN05MiRsJqqqirl5+fL7XbL7XYrPz9f1dXVYTUlJSW66aablJKSoqFDh2rhwoUdZhsDQKQQ9gBEQo/D3g9/+ENVVlbKGKPk5GQ99thjevvtt/X888/3+L65W7du1d13362dO3dqy5Ytam5u1syZM1VfXx+qWb16tR5++GGtXbtWe/bsUVZWlmbMmKHa2tpQzaJFi/TCCy+ooKBA27ZtU11dnWbPnq1AIBCqmTt3roqLi1VYWKjCwkIVFxcrPz8/tD0QCGjWrFmqr6/Xtm3bVFBQoI0bN2rx4sU9/ScCgF7hdmkAIsL00E033WScTqfJzs429957r3nzzTd7uosuVVRUGElm69atxhhjgsGgycrKMg8++GCopqmpybjdbvOLX/zCGGNMdXW1SUhIMAUFBaGao0ePGqvVagoLC40xxhw4cMBIMjt37gzV7Nixw0gy7733njHGmE2bNhmr1WqOHj0aqnn22WeN0+k0Ho+nW/17PB4jqdv1AGCMMVOmTDFTpkwxx44di3YrAM4h3c0dPR7Ze/HFF1VeXq7ly5erqKhI48aN09ixY7Vy5UodOnTorIKnx+ORJA0ePFhSy23aysvLNXPmzFCN0+nUlClTtH37dklSUVGR/H5/WE12drby8vJCNTt27JDb7Q4dfpZazj10u91hNXl5ecrOzg7VXHfddfJ6vSoqKjqr7wUA3dH2aAQA9JVe3S5t0KBBuvPOO/Xaa6/p8OHD+spXvqINGzZo1KhRvW7EGKN7771Xn/rUp5SXlydJKi8vlyRlZmaG1WZmZoa2lZeXy+FwKD09/bQ1GRkZHT4zIyMjrKb956Snp8vhcIRq2vN6vaqpqQlbAKC3OIwLIBLO6t64fr9fe/fu1a5du3To0KEOYakn7rnnHr399tt69tlnO2xrf3NwY8wZbxjevqaz+t7UtLVq1arQhA+3262cnJzT9gQAp2O1crtyAH2vVz9Z/vrXv2revHnKzMzUbbfdJpfLpZdeekmlpaW9amLBggV68cUX9de//lUjRowIrc/KypKkDiNrFRUVoWCZlZUln8+nqqqq09YcO3asw+dWVlaG1bT/nKqqKvn9/i5D7LJly+TxeEJLb78/AABApPQ47I0YMUI33nijKisrtW7dOh07dky//vWvNX369B7/VWqM0T333KPnn39e//u//6uRI0eGbR85cqSysrK0ZcuW0Dqfz6etW7fq6quvliSNGzdOCQkJYTVlZWXav39/qGbSpEnyeDzavXt3qGbXrl3yeDxhNfv371dZWVmoZvPmzXI6nRo3blyn/TudTqWlpYUtAAAAsaTHF1X+/ve/r89//vMdzpHrjbvvvlvPPPOM/vjHP8rlcoVG1txut5KSkmSxWLRo0SKtXLlSubm5ys3N1cqVK5WcnKy5c+eGau+44w4tXrxYQ4YM0eDBg7VkyRJddtllmj59uiRpzJgxuv766zVv3jytW7dOknTnnXdq9uzZGj16tCRp5syZGjt2rPLz87VmzRqdPHlSS5Ys0bx58whxAPoFEzQARETE5wWfhqROl1//+tehmmAwaJYvX26ysrKM0+k011xzjdm3b1/YfhobG80999xjBg8ebJKSkszs2bNNSUlJWM2JEyfMrbfealwul3G5XObWW281VVVVYTWHDx82s2bNMklJSWbw4MHmnnvuMU1NTd3+Plx6BUBvtF565dChQ9FuBcA5pLu5w2IMl2zvKzU1NXK73fJ4PIwGAui2qVOnSpKeeOIJfexjH4tuMwDOGd3NHUz9AgAAiGOEPQCIERxoARAJhD0AiBGEPQCRQNgDgBjBbFwAkUDYA4AY0dzcHO0WAMQhwh4AxAhG9gBEAmEPAGIEYQ9AJBD2ACBGMEEDQCQQ9gAgRgSDwWi3ACAOEfYAAADiGGEPAGKEw+GIdgsA4hBhDwBihN1uj3YLAOIQYQ8AYgRhD0AkEPYAIEYQ9gBEAmEPAGKEzWaLdgsA4hBhDwBiBGEPQCQQ9gAAAOIYYQ8AYgR30AAQCYQ9AIgR3EEDQCQQ9gAAAOIYYQ8AYgSHcQFEAmEPAGIEh3EBRAJhDwBiBCN7ACKBsAcAMYKwByASCHsAECMIewAigbAHADGCsAcgEgh7ABAjCHsAIoGwBwAxgrAHIBIIewAQI7j0CoBIIOwBQIxgZA9AJBD2AAAA4hhhDwBiRCAQiHYLAOIQYQ8AYoTP54t2CwDiEGEPAKKo7aQMwh6ASCDsAUAUtQ14TU1NUewEQLwi7AFAFLUd2WM2LoBIIOwBQBTZbLZOnwNAXyHsAUAUtQ14Vis/kgH0PX6yAEAUEfYARBo/WQAgiiwWS+i53W6PYicA4hVhDwBiBGEPQCQQ9gAAAOIYYQ8Aoqjt5Va4qDKASCDsAUAU+f3+0HPCHoBIIOwBQBS1DXherzeKnQCIV4Q9AIiitiN7zc3NUewEQLwi7AFAFBH2AEQaYQ8Aoohz9gBEGmEPAKKo7Xl6nLMHIBIIewAQRQ0NDZ0+B4C+QtgDgChqbGwMPSfsAYgEwh4ARFHbgNc2+AFAXyHsAUAUcRgXQKQR9gAgigh7ACKNsAcAUVRTU9PpcwDoK4Q9AIii48ePS5KMxaLKysoodwMgHhH2ACCKWgNeMGWYqqurwy6yDAB9gbAHAFFUUVEhY3cq6EyT9NFIHwD0FcIeAESJMUZlZWUKOlIVdLokSWVlZVHuCkC8IewBQJRUV1fL6/Uq6HQp6EyVRNgD0PcIewAQJaWlpZKkoNMlc+owbklJSTRbAhCHCHsAECVvvvmmJCmQmqlAyhDJalNxcXF0mwIQdwh7ABAle/fulSwWBVxZktWu5tQMffDBB/J4PNFuDUAciWrYe/3113XTTTcpOztbFotFf/jDH8K2G2P0wAMPKDs7W0lJSZo6dareeeedsBqv16sFCxZo6NChSklJ0Zw5c3TkyJGwmqqqKuXn58vtdsvtdis/P1/V1dVhNSUlJbrpppuUkpKioUOHauHChfL5fJH42gCgxsZGHThwQIGUYZLdIUkKpGXLGMPoHoA+FdWwV19fryuuuEJr167tdPvq1av18MMPa+3atdqzZ4+ysrI0Y8YM1dbWhmoWLVqkF154QQUFBdq2bZvq6uo0e/ZsBQKBUM3cuXNVXFyswsJCFRYWqri4WPn5+aHtgUBAs2bNUn19vbZt26aCggJt3LhRixcvjtyXBzCglZeXKxAIKJA8OLQukDxEkjr8wQoAZ8MezQ+/4YYbdMMNN3S6zRijn/zkJ7r//vv1uc99TpL0m9/8RpmZmXrmmWf09a9/XR6PR+vXr9eGDRs0ffp0SdJTTz2lnJwc/eUvf9F1112nd999V4WFhdq5c6cmTJggSfrVr36lSZMm6f3339fo0aO1efNmHThwQKWlpcrOzpYk/fjHP9btt9+uH/3oR0pLS+uHfw0AA0nrxZSNIyW0rvU5d9IA0Jdi9py9gwcPqry8XDNnzgytczqdmjJlirZv3y5JKioqkt/vD6vJzs5WXl5eqGbHjh1yu92hoCdJEydOlNvtDqvJy8sLBT1Juu666+T1elVUVNRlj16vVzU1NWELAHRHRUWFJCmY8FHYa31O2APQl2I27JWXl0uSMjMzw9ZnZmaGtpWXl8vhcCg9Pf20NRkZGR32n5GREVbT/nPS09PlcDhCNZ1ZtWpV6DxAt9utnJycHn5LAANV6yVWgoltjhzYEmTsTh0+fDhKXQGIRzEb9lpZLJaw18aYDuvaa1/TWX1vatpbtmyZPB5PaGm9ZhYAnMk//vEPSRYFk9r8sWqxKJA8REeOHFF9fX3UegMQX2I27GVlZUlSh5G1ioqK0ChcVlaWfD6fqqqqTltz7NixDvuvrKwMq2n/OVVVVfL7/R1G/NpyOp1KS0sLWwDgTIwx+uCDDxRIdEu2hLBtrZM0/vnPf0ajNQBxKGbD3siRI5WVlaUtW7aE1vl8Pm3dulVXX321JGncuHFKSEgIqykrK9P+/ftDNZMmTZLH49Hu3btDNbt27ZLH4wmr2b9/f9htijZv3iyn06lx48ZF9HsCGHhKS0tVX1+vYMqQDtuCKUMlSe+++25/twUgTkV1Nm5dXV3YX68HDx5UcXGxBg8erPPPP1+LFi3SypUrlZubq9zcXK1cuVLJycmaO3euJMntduuOO+7Q4sWLNWTIEA0ePFhLlizRZZddFpqdO2bMGF1//fWaN2+e1q1bJ0m68847NXv2bI0ePVqSNHPmTI0dO1b5+flas2aNTp48qSVLlmjevHmM1gHoc2+//bakljtntNe6bt++ffriF7/Yr30BiE9RDXt79+7VtddeG3p97733SpJuu+02Pfnkk1q6dKkaGxs1f/58VVVVacKECdq8ebNcLlfoPY888ojsdrtuueUWNTY2atq0aXryySdls9lCNU8//bQWLlwYmrU7Z86csGv72Ww2vfLKK5o/f74mT56spKQkzZ07Vw899FCk/wkADED79u2TpJY7Z7RjHMkKOl16++23FQwGZbXG7AEYAOcIizHGRLuJeFFTUyO32y2Px8OIIIBOGWP0+VtuUWVVrequ/JLUySSwxIN/U8Lxf+hXv/qVcnNzo9AlgHNBd3MHfzICQD969913dbyyUv5BOZ0GPUlqHnS+JGnr1q392RqAOEXYA4B+9Nprr0mSmtMv7LKm2X2eZEvQa6+9Jg6+ADhbhD0A6Cc1NTXa8pe/yNgdCqRld11otcvvHqEjR45o7969/dcggLhE2AOAfmCM0UMPPaSqkyfly7pMstpOW+/LulyyWLVq1SpVV1f3T5MA4hJhDwD6wUsvvaTXX39dza7hLWHvDIIpQ9Q0YrxOnjypBx98kMO5AHqNsAcAEVZcXKz/t3atjD1RTR+bIlm696PXn3mpmt0jtHPnTj3xxBMEPgC9QtgDgAj629/+pv/8z/+U3x9Q48eukXEkd//NFouaRv6bgs40bdiwQY8++qiCwWDkmgUQlwh7ABAhmzZt0ve/v1z+oNRw8QwF3CN6vA+TkKSGMTcqkDxYL7zwgn70ox/J7/dHoFsA8YqwBwAR8Lvf/U6rV69W0O5Q/egbTj/79gxMQrIaRt+oZleWXn31Vd1///3y+Xx92C2AeEbYA4A+9uqrr+pnP/uZjCNF9ZfMUjBl6Nnv1O5Q48Uz1TwoR7t379aaNWs4hw9AtxD2AKAPvfXWW1q1apVkc6jh4pkyie6+27nVrsaLrlVzaqa2bNmiJ554ou/2DSBuEfYAoI+UlJTo/vvvV3MgqIZR0xRMSu/7D7Ha1Zg7TcFEtzZs2KCXX3657z8DQFwh7AFAH6iurtZ9992nuro6NV74KQXShkfuw+yJasidIZOQqEceeURFRUWR+ywA5zzCHgCcJZ/Pp+9973sqKyuTN/vjah46KuKfaRLT1DBqugJG+t73v6/Dhw9H/DMBnJsIewBwFowxWrNmjfbt2yf/4Ivky76y3z47mJqhxgs/pYb6en3729/mtmoAOkXYA4Cz8Nxzz2nLli1qTs1Q08jJksXSr5/fPOQiebM/rrKyMj3wwANqbm7u188HEPsIewDQS3v37tW6db+UcaSoadQ0yWqPSh++7CvlTx+p4uJirVu3Lio9AIhdhD0A6IWysjKtWLFCxmJRw6hpMglJ0WvGYlHTyE8pmJSu3/3ud9qyZUv0egEQcwh7ANBD5eXlWnrffaqtrVXjBVf3zUWTz5YtQQ2jpkl2h1avWaPt27dHuyMAMYKwBwA98MEHH+gb35iv0pISeYdfoeahudFuKcQkpqnhok/LHwjq/vu/qz/+8Y/RbglADCDsAUA37dq1SwsWLlRVVZWazp8o34hx0W6pg0BatupH36ig3alHHnlE69atUzAYjHZbAKKIsAcAZ2CM0e9+9zstW7ZMXl+zGkZNkz9zbLTb6lIwZajqx8xWMNGtZ599VitWrFBdXV202wIQJYQ9ADiNqqoqLVu2TD/72c8UsDlVP/oGBdLPj3ZbZ2ScLtWPma1m13Bt3bpVd3zta3rnnXei3RaAKCDsAUAX9u7dq69+9Q7t3LlTze4Rqr/0ZgVTh0W7re6zO9U4+jp5z/uEjpUf04IFC7RhwwYFAoFodwagH1mMMSbaTcSLmpoaud1ueTwepaWlRbsdAL0UDAb1xBNP6KmnnpIsNjWNGN9y2LafL5jcl2y1x5T0r62y+Or08Y9/XMuXL9egQYOi3RaAs9Dd3MHIHgC00dzcrFWrVumpp55SMNGt+jGz5c+69JwOepIUcGWq7tLPyJ9+od58800tWLhQx44di3ZbAPoBYQ8ATmlqatJ3v/vd0O3P6sfMVjBlSLTb6jt2p5ouulbe4ZertKREd999jw4fPhztrgBEGGEPANRyOGTJkiWnzs/LUePF10t2Z7Tb6nsWi3wjxqsp55M6frxS9yxYwMQNIM4R9gAMeH//+9/1la9+Vfv375d/yEVqHDVNskXnPrf9xZ+Vp8aR/6ba2lotXLhQzzzzDBM3gDjFBI0+xAQN4Nzi8/m0fv16Pffcc5LFKu95n5Av67Jz/vy8nrDVlCnp4Ouy+Op1xRVX6Dvf+Y4yMzOj3RaAbmCCBgCcxqFDhzR//nw999xzoYkYvuGXD6igJ0mBtOGqu/Rm+dMv1FtvvaWvfPWrevXVV8U4ABA/GNnrQ4zsAbGvurpaGzZs0B/+8EcFAs3yDbtE3pxPxv1h2zMyRvYT/1RSyU4p4Ne4ceN01113KTc3du79CyBcd3MHYa8PEfaA2OX1erVx40Y99fTTaqivVzAxTU05ExQYlBPt1mKKpalGiSW7ZPeUymKxaMaMGbrjjjs4tAvEIMJeFBD2gNgTDAa1ZcsWPf7446qsrJRJSJR3+JXyD7tEsnImS1dsNWVylu6WreGEEhIS9O///u+aO3euXC5XtFsDcAphLwoIe0Ds8Pv9evXVV1VQUKBDhw5JVru8mZfKN/wyyeaIdnvnBmNkP/kvJR4pksVXp9TUVH32s5/V5z73OaWnp0e7O2DAI+xFAWEPiL66ujq99NJL+v3vf68TJ05IFqt8Q0bJd97HZRwp0W7v3BRsVkLFu3KW75fF36iEhARdf/31uuWWW5STw2FwIFoIe1FA2AOip6KiQr///e/10ksvq7GxQbI55Bs2Wr7MsYS8vhJsVsLxf8px7B1ZmzyyWCyaPHmyvvjFLyovLy/a3QEDDmEvCgh7QP8qKytTUVGRdu/erTfeeEOBQEDGkSJvxlj5h42W7ByujQhjZK8ukaN8n2x1FZKkMWPGaPLkyRo/frxyc3Nls9mi3CQQ/wh7UUDYAyKrvr5eb775pvbu3as9e/bq6NEjoW2BpHT5svLUPPhjkpWg0V+stcfkKN+nhOpSSS2/Tlwul8aNG6fx48dr/PjxysrKim6TQJwi7EUBYQ/oW83NzXr//fe1Z88e7d27VwcOHFAwGJQkGZtDzWnDFUg7T81p2TKJ/D8XVc1e2WvKZKs5KnvNh7J6a0ObRowYofHjx+uqq67SlVdeqZQUDqsDfYGwFwWEPaB3jDGqqqpSWVmZysvLVVZWpvfee09vvvmm6uvrW4osFjWnZCiQlq1m93kKpgyVLFw6JVZZmmpkrzkqm+dD2WvLZAn4JElWq1Vjx47VFVdcoezsbA0fPlzDhw/XsGHDZLcP8AtbAz1E2IsCwh7QtdraWpWXl4fCXNulvLxcXq+3w3uCiW41p2WrOe08BdKyuGTKucoEZa0/LrvnaMvIX32l1O5Xj9VqVUZGRij8ZWVlhT0fPHiwrFwXEQhD2IsCwh4GsqamJh07dqxDiCsrK9OHZWWqr6vr9H3G7lTQ4VLQmSrjbHkMOl0KJg6Scab287dAv2j2ydZ4UhZvrazeWlm9dbL46lqe++o7fYvD4VBmZmYoALYPhC6XS5YBdl9joLu5gzFzAKdljFFDQ4M8Ho9qamrk8XhUWVnZYYSuqqqq8x1Y7Qo4XTKDck6FOpdMa6BzpjJaNxDZHQq4siRXJxM3ggFZfPWnQmCtLN46WX21CnhrVVJWqdLS0k53mZycHBb+hg8froyMDA0aNEhpaWlyu91yuVzMEsaARNgDBhBjjBobG+XxeDosrUGu7evqao88NR4Fmpu73qnFqqAjVcG088JH5xwtoc7YEyVGXNBdVptMYpoCiWkKdLY94JfVV3dqVLDuVCCsVa23TvWHj+hf//pXl7u2WCxyuVxyu90dltZA2H6dy+Xi8DHOeYQ94BzVGtw6C2mdBbnq6mp5PB41ny64td2/3dmyJA5W0J546nWiZHcqmJB0KtS5ZBKSCXPoP7YEBZPSpaT0jmHQGCng+2hU0NcgS3OTLM3eU49NqvJ75Sk/IcuRo5IJnvHjLFarXC6XBp0mFLZfUlJSCIiIKYQ9IAa0Brfa2trThrb2i9/v797+7U4Zm1PGOVgmtSW0tYa38Oetjw5muuLcY7G0/DFid7bM1j4dY6SgXxZ/2zD4UShsed7yusrXJE9ZpSylR7odENNcaRo06PSjhm2fp6SkcIgZEUPYA/qAMUZer1d1dXVhS21t7Wlfh9bV18sEz/xLRJKM3SFjS5RxDJJJTpRJSGwJcgldhTcnwQ1oz2KRbA4Zm0PdnqVojBTwtwuEnT+e9Dap+sMKWUpKOsw87kpSUrJSXalKc7mUmpra5eJqt93lcikpKYnRRHSJsAec4vf7exzU2q7v7uHREFuCgq2/bFIyZGyOll8+rUEtobMRN4IbEDUWi2R3tPzBpW5eceHUoeVORw/9p54HfLIEvKpr9qne06iKkx5Zmn1S92OoLFarUpJT5HJ1DINnCoupqalKTExkNnMcI+whbgQCAdXX1/c6rHV2nbfTstplbA4FbQ4pcXBLaLM5T428tSyyO1uet1ln7E7JlkBoAwaCU4eWjd3Z/YAonTrM3NwSDgO+lotSN7eEQkuzL7TO0uxtCZMBnzzNPtWcqJG14oR06iLW3WWz25WakiqXq+tAeLrA6HAwqz6WEfYQk4wxqqurC52bVl1dHVo6e11bW6uGhoaefYjFeupctgQZu0vGObRdUDsV3tqGNbszdOiH+68CiBiLRbIltPx86s37TfDUIWdvm2DoOxUM2wdGn5oDXvl8PlUdOynrh+VSsGdHKhwOp1JdqRrkdmvQoEGh8xEHDRoUWtq+TktL4xzFfkTYQ78IBoOhCQdnCm5Vpx5Pe7mPVlb7qZmiSTIu96nw1no49KOAFr7O+VFY47AFgHhksbYZUeyFYKBlNPFUGLS0C4lqty4Q8Kmp3qsTnqOynObyN6H2Tl0Gp6sw6G4TGlvXJSQk9OabQIQ99FJzc3O3glt1dbWqqqtVW1vbrQkIHS/30XruWufPZeU/YQDoc1abjDVJSkjqeVg0wZYRRX/rRJbGNs8/Wl/lb5nlXFJa2q1JLMnJyWHhsH0YbD+imJSU1KuvHo/4TYkzKi0t1eOPP64TJ06EwltXt74KZ5FJSFTQ7myZgHC68JaQKGNLlJhNBgDnNotVJiFJJqGbYat1Eou/SdbmxlOTV9pMZjkVDmubm1R33KMPy49JwU4vuR3G4XSGDisPGjRIs2bN0pQpU87yy52bCHs4o8OHD+v111/XmW6jbKx2BZIHK5g8VIGUIQompcs4Uk/NIOVwKQCgE20msQTkPn1twC+rr17WpmpZ60/I1nBC1oYTsvobO5T6vF5VVFSooqJCkpSRkTFgw57FnOk3OLqtuzckPhdVV1fr2LFjqqioUGVlZeh/oNbl+PHjCnZ1mNZqVzAhWUFHiowjpd1jqoKOFMnOTC4AGNBa74vsq+/ksU5Wf0PL7OMuuN2DlJmZoWHDhikjIyO0tH0db9ci7G7uYGQP3dI6DD569OhOtwcCAZ08ebLTMFhZWaljxypUVVXe9eigLUGBhPAwaOyOlsubWGwtj9a2jzYZq/2j1xY7Ey4AIBqMaZn9G2yWJRgIfzThrxUMyBJsbll8DS0hzlffEuQ6GZ1rlZKaqszh53UIb62vhw0bJqfT2Y9f+txC2EOfsNlsof/huuL3+3X8+PFOw2BFRYWOVVSoxnP07Bqx2kLhz7R73jEw2j8KjZbW8GjrWBsKm6cCpfWjWq6VByDmGNNyTpvpJHy1fTQtwas1gKnTmtO9t/V9PbygfDuJiYnKGN75SFzr6+Tk5D76xxmYCHvoNwkJCRo+fLiGDx/eZY3X61VlZaUqKytVX18vr7fl2k9er7fTpf22zmsb5G1o6vow89mwWEPB0HQSGMNGIC3hQdF0ETY7jFqGjV4SLoFzjgm2C1QBWUx4yOrwaM4UwsLf035dX7NYLHI4HHI6nWFL+3UOh0OJiYldbmv7eujQocrIyFBqaip374gwwh5iitPp1IgRIzRixIg+33dzc3MvgmL3altfNzU1yettlLfJ173rBPaUxRIKjiZshLHr0cvwEcq2obJtjV3GlnDqeYJkszNqifjWeoeKYHPLxYeDfilw6nVYkGoftFrDWPhhyfZBzdLmvTJ9/4em1WqVw+mU0+GU05l0xhB2poDW2evExMTQ84SEBALZOYywhwHDbrfLbrcrJSWlXz4vEAh0Oyi2hMTuh8rWpal1vbdWfr+/b7+A1SZjTTgVKlsC4EeP9k7WJbQEydC6hHZ1dsmawOgkeiYUylrDmF+WQLPU9jHY3HFbKMQ1h61ree0/60OP7dnsdjkdDjmTnHI6U7sdrHobwux2fn2j+/ivBYgQm82m5OTkfjvXJBgMhoXB040+dgiNTU1qbGwMPbZ/3rLUqam+6ewbtVhbbgHVGgStdhlbSxA0tjOta/cYek6IjLrWE/TbBqtToarzdafZdiq09cX5YJKU4HAoKSlJSYnJLY9tlsTExNBj69KbEEb4Qizjv04gTlit1tAvq0gJBoNdhsPOQuKZ6hoaG9XYWC9vXdMZr+N4RmEh8qOgqFMjjm3Do0KjkO22ha1rCZRxN8PbqOWk+zajY5Zg+wDmDwWtlnWtI2YdR9Yswb4LZQ6H81QISw0LYl2Fs/bruqrjHqwY6Ah77Tz22GNas2aNysrKdOmll+onP/mJ/u3f/i3abQExwWq1hn6Zpqen99l+jTFhIbKz8Hj6UcfwuoaGRjU2Nqipvqlbt+lDzzidraHMdcbg1dm2zsKZ0+kklAERQthr47nnntOiRYv02GOPafLkyVq3bp1uuOEGHThwQOeff3602wPilsViCY1KDho0qM/2a4yRz+fr1ahj62NEZnFH2UdhreejZ4mJiXF3YVog3nEHjTYmTJigT3ziE/r5z38eWjdmzBjdfPPNWrVq1RnfH8930AAAALGlu7mDP89O8fl8Kioq0syZM8PWz5w5U9u3b+/0PV6vVzU1NWELAABALCHsnXL8+HEFAgFlZmaGrc/MzFR5eXmn71m1apXcbndoycnJ6Y9WAQAAuo2w1077i0YaY7q8kOSyZcvk8XhCS2lpaX+0CAAA0G1M0Dhl6NChstlsHUbxKioqOoz2tWq9xhIAAECsYmTvFIfDoXHjxmnLli1h67ds2aKrr746Sl0BAACcHUb22rj33nuVn5+v8ePHa9KkSfrlL3+pkpIS3XXXXdFuDQAAoFcIe2184Qtf0IkTJ/SDH/xAZWVlysvL06ZNm3TBBRdEuzUAAIBe4Tp7fYjr7AEAgP7CdfYAAABA2AMAAIhnhD0AAIA4RtgDAACIY8zG7UOtc124Ry4AAIi01rxxprm2hL0+VFtbK0ncIxcAAPSb2tpaud3uLrdz6ZU+FAwG9eGHH8rlcnV5P10AaK+mpkY5OTkqLS3lsk0Aus0Yo9raWmVnZ8tq7frMPMIeAEQZ1+gEEElM0AAAAIhjhD0AAIA4RtgDgChzOp1avny5nE5ntFsBEIc4Zw8AACCOMbIHAAAQxwh7AAAAcYywBwAAEMcIewAAAHGMsAdgwHvzzTf1+c9/XpmZmUpMTNTFF1+sefPm6YMPPujXPl577TVZLBZVV1d3+z233367LBaLLBaL7Ha7zj//fH3jG99QVVVVWN2FF14oi8WinTt3hq1ftGiRpk6d2mG/R44ckcPh0CWXXNKbrwIghhD2AAxoL7/8siZOnCiv16unn35a7777rjZs2CC3263vfe970W6vW66//nqVlZXp0KFDevzxx/XSSy9p/vz5HeoSExN13333dWufTz75pG655RY1NDTojTfe6OuWAfQjwh6AuDZ16lQtXLhQS5cu1eDBg5WVlaUHHnhAktTQ0KCvfOUruvHGG/Xiiy9q+vTpGjlypCZMmKCHHnpI69atC+1n69at+uQnPymn06nhw4fr29/+tpqbm0PbL7zwQv3kJz8J++wrr7wy9FmSZLFY9Pjjj+uzn/2skpOTlZubqxdffFGSdOjQIV177bWSpPT0dFksFt1+++3d+o5Op1NZWVkaMWKEZs6cqS984QvavHlzh7qvf/3r2rlzpzZt2nTa/Rlj9Otf/1r5+fmaO3eu1q9f360+AMQmwh6AuPeb3/xGKSkp2rVrl1avXq0f/OAH2rJli/785z/r+PHjWrp0aafvGzRokCTp6NGjuvHGG3XVVVfprbfe0s9//nOtX79e//Vf/9XjXlasWKFbbrlFb7/9tm688UbdeuutOnnypHJycrRx40ZJ0vvvv6+ysjL99Kc/7fH+//Wvf6mwsFAJCQkdtl144YW66667tGzZMgWDwS738de//lUNDQ2aPn268vPz9T//8z+qra3tcS8AYgNhD0Dcu/zyy7V8+XLl5ubqP/7jPzR+/Hi9+uqr+sc//iFJZzwv7bHHHlNOTo7Wrl2rSy65RDfffLNWrFihH//4x6cNTZ25/fbb9aUvfUmjRo3SypUrVV9fr927d8tms2nw4MGSpIyMDGVlZcntdndrny+//LJSU1OVlJSkiy66SAcOHOjycO13v/tdHTx4UE8//XSX+1u/fr2++MUvymaz6dJLL9WoUaP03HPP9eh7AogdhD0Ace/yyy8Pez18+HBVVFSouzcQevfddzVp0iRZLJbQusmTJ6uurk5HjhzpdS8pKSlyuVyqqKjo0T7au/baa1VcXKxdu3ZpwYIFuu6667RgwYJOa4cNG6YlS5bo+9//vnw+X4ft1dXVev755/XlL385tO7LX/6ynnjiibPqEUD0EPYAxL32hzQtFouCwaAuvvhiSdJ777132vcbY8KCXuu61n1JktVq7RAe/X5/t3s5GykpKRo1apQuv/xyPfroo/J6vVqxYkWX9ffee68aGxv12GOPddj2zDPPqKmpSRMmTJDdbpfdbtd9992nHTt26MCBA2fVJ4DoIOwBGLBmzpypoUOHavXq1Z1ub70EytixY7V9+/awMLd9+3a5XC6dd955klpGzMrKykLba2pqdPDgwR7143A4JEmBQKBH72tv+fLleuihh/Thhx92uj01NVXf+9739KMf/Ug1NTVh29avX6/FixeruLg4tLz11lu69tprGd0DzlGEPQADVkpKih5//HG98sormjNnjv7yl7/o0KFD2rt3r5YuXaq77rpLkjR//nyVlpZqwYIFeu+99/THP/5Ry5cv17333iurteXH6Kc//Wlt2LBBf/vb37R//37ddtttstlsPernggsukMVi0csvv6zKykrV1dX16ntNnTpVl156qVauXNllzZ133im3261nn302tK64uFh///vf9bWvfU15eXlhy5e+9CX99re/7XS0EkBsI+wBGNA+85nPaPv27UpISNDcuXN1ySWX6Etf+pI8Hk9otu15552nTZs2affu3briiit011136Y477tB3v/vd0H6WLVuma665RrNnz9aNN96om2++WRdddFGPejnvvPO0YsUKffvb31ZmZqbuueeeXn+ve++9V7/61a9UWlra6faEhAT98Ic/VFNTU2jd+vXrNXbs2E4nrNx88806efKkXnrppV73BCA6LKa7ZygDAADgnMPIHgAAQBwj7AFAjCopKVFqamqXS0lJSbRbBHAO4DAuAMSo5uZmHTp0qMvtF154oex2e/81BOCcRNgDAACIYxzGBQAAiGOEPQAAgDhG2AMAAIhjhD0AAIA4RtgDAACIY4Q9AACAOEbYAwAAiGOEPQAAgDj2/wGe9yz9IEBo2AAAAABJRU5ErkJggg==",
+      "text/plain": [
+       "<Figure size 804.6x480 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "sc.pl.violin(adata, ['nCount_RNA'], stripplot = False)\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5ac2cc66-443d-4e1a-982f-d1b6304c7f3c",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "356ac708-6608-4f39-99cc-a151c23ecd7c",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "398ae977-83f9-4336-ac2c-3bebb2b9efc2",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fd2b8d99-0f61-4034-95b1-b557608006d0",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b212775b-e21b-412e-b30c-32e21406f080",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0ba9a416-d96e-4895-9426-2df3f962fabd",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/analysis/project_analysis.ipynb
+++ b/analysis/project_analysis.ipynb
@@ -1,0 +1,113 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "97cd7650-7a4a-402d-b450-4d2d84e6c1a1",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import scanpy as sc"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "a7adfddf-a288-4dae-ad79-6c22d65838c6",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "#load gene names file\n",
+    "df_genes = pd.read_csv('../data/genes.tsv', sep='\\t', header=None, names=['GeneName'])\n",
+    "\n",
+    "#create gene ID column\n",
+    "df_genes['GeneID'] = ['Gene_' + str(i) for i in range(len(df_genes))]\n",
+    "\n",
+    "#order columns to match scanpy format\n",
+    "df_genes = df_genes[['GeneID', 'GeneName']]\n",
+    "\n",
+    "#save to genes.tsv\n",
+    "df_genes.to_csv('../data/genes.tsv', sep='\\t', index=False, header=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "b64a54ad-d264-47bd-ab84-ea3f5ddb87ee",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        0              1\n",
+      "0  Gene_0   RP11-34P13.7\n",
+      "1  Gene_1     FO538757.3\n",
+      "2  Gene_2     FO538757.2\n",
+      "3  Gene_3     AP006222.2\n",
+      "4  Gene_4  RP4-669L17.10\n"
+     ]
+    }
+   ],
+   "source": [
+    "#load tsv file into DataFrame\n",
+    "df = pd.read_csv('../data/genes.tsv', sep='\\t', header = None)\n",
+    "print(df.head())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "434cbdd3-9d17-4da2-abcb-1fd942049929",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "AnnData object with n_obs × n_vars = 100064 × 29733\n",
+      "    var: 'gene_ids'\n"
+     ]
+    }
+   ],
+   "source": [
+    "#set file path\n",
+    "data_path = '../data/'\n",
+    "\n",
+    "#read in data\n",
+    "adata = sc.read_10x_mtx(data_path, var_names='gene_symbols', cache=True)\n",
+    "print(adata)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Adds Jupyter notebook `project_analysis.ipynb` that functions as location of Python alternative to the workflow performed in `project_analysis.R`. Includes data reformatting and violin plots displayed for HER2+ subtype specifically. Will continue to make additions in future commits.

Also edits README to contain instructions on what file to download from GEO, where to store it to run analysis, and some direction on future objectives for `project_analysis.ipynb`.