### PR TITLE
Updated filepaths to redirect to `analysis`

### DIFF
--- a/report/analysis_report.ipynb
+++ b/report/analysis_report.ipynb
@@ -26,24 +26,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "id": "97cd7650-7a4a-402d-b450-4d2d84e6c1a1",
    "metadata": {
     "tags": []
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "/Users/joshuagalla/Downloads/Work:School Apps/App Info/Github/BIOINF545/notebooks\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import sys\n",
     "import os\n",
-    "sys.path.append(os.path.abspath('../'))\n",
+    "sys.path.append(os.path.abspath('../analysis'))\n",
     "\n",
     "import preprocessing\n",
     "import processing\n",
@@ -63,7 +55,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": 4,
    "id": "0d1e2cd1-c017-4c5d-921b-0e5ab35b278c",
    "metadata": {
     "tags": []
@@ -143,7 +135,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 42,
+   "execution_count": 5,
    "id": "a7adfddf-a288-4dae-ad79-6c22d65838c6",
    "metadata": {
     "tags": []


### PR DESCRIPTION
edited filepaths in `analysis_report.ipynb` to specifically redirect to `analysis` directory in order to avoid errors revolving around inability to locate .py script files